### PR TITLE
Refactored how we handle updates

### DIFF
--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -97,7 +97,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
 
     fn build_compute_properties_fn(&self) -> Option<Box<dyn Fn(&ExpandedNode, &ExpressionTable, &Globals)>> {
         Some(Box::new(|node, table, globals|{
-            let props = &node.properties;
+            let props = &node.properties.borrow();
             let properties = &mut props.as_ref().borrow_mut();
 
             if let Some(properties) = properties.downcast_mut::<{{component.pascal_identifier}}>() {

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -36,7 +36,7 @@ impl NodeContext<'_> {
     }
 
     pub fn get_nodes_by_global_id(&self, uni: UniqueTemplateNodeIdentifier) -> Vec<NodeInterface> {
-        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_global_ids(uni);
+        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_global_ids(&uni);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -77,7 +77,7 @@ impl InstanceNode for ComponentInstance {
                 Some(containing_component.create_children_detached(children_with_env, context));
         }
 
-        let new_env = expanded_node.stack.push(&expanded_node.properties);
+        let new_env = expanded_node.stack.push(&expanded_node.properties.borrow());
         let children = self.template.borrow();
         let children_with_envs = children.iter().cloned().zip(iter::repeat(new_env));
         expanded_node.set_children(children_with_envs, context);
@@ -94,5 +94,9 @@ impl InstanceNode for ComponentInstance {
 
     fn base(&self) -> &BaseInstance {
         &self.base
+    }
+
+    fn get_template(&self) -> Option<&InstanceNodePtrList> {
+        Some(&self.template)
     }
 }

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -30,7 +30,8 @@ impl Space for NodeLocal {}
 
 impl NodeInterface {
     pub fn global_id(&self) -> Option<UniqueTemplateNodeIdentifier> {
-        let base = self.inner.instance_node.base();
+        let instance_node = self.inner.instance_node.borrow();
+        let base = instance_node.base();
         base.template_node_identifier.clone()
     }
 

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -239,6 +239,10 @@ pub trait InstanceNode {
     fn handle_scroll(&self, args_scroll: Scroll) {
         //no-op default implementation
     }
+
+    fn get_template(&self) -> Option<&InstanceNodePtrList> {
+        None
+    }
 }
 
 pub struct BaseInstance {


### PR DESCRIPTION
the update_userland_component function doing un-necessary work (especially during move). 
In this PR:
-  we refactor it to handle partial updates to a single template node. 
-  Split up the full reload pass between pause and play mode so we don't have to generate the full userland project twice when it isn't rendered

This should lower updating time during move by a fair amount and by about half for adds/removes.
Still further performance work to be done but this should be noticeable in the designer. 