### PR TITLE
fix expressions that start with !

### DIFF
--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -19,7 +19,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext) -> Box<dyn Any>>> = HashMap::new();
 
     {% for expression_spec in expression_specs %}
-    //{{ expression_spec.input_statement.content}}
+    // {{ expression_spec.input_statement.content}}
     {% if expression_spec.input_statement.source_map_start_marker %}
         {{ expression_spec.input_statement.source_map_start_marker }}
     {% endif %}


### PR DESCRIPTION
Tiny fix:  previously expressions that start with `!` (e.g. `if !some_condition { <Group /> }`) would upset the reserved meaning of `//!` in Rust.  This fixes.