### PR TITLE
Hooked up Dirty Dag without repeat & conditional etc

### DIFF
--- a/examples/src/fireworks/Cargo.toml
+++ b/examples/src/fireworks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.12.8"}
-pax-std = { version = "0.12.8"}
-pax-compiler = { version = "0.12.8", optional = true}
-pax-manifest = { version = "0.12.8"}
+pax-engine = { version = "0.12.8", path = ".pax/pkg/pax-engine" }
+pax-std = { version = "0.12.8", path = ".pax/pkg/pax-std" }
+pax-compiler = { version = "0.12.8", optional = true, path = ".pax/pkg/pax-compiler" }
+pax-manifest = { version = "0.12.8", path = ".pax/pkg/pax-manifest" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/one-rect/Cargo.toml
+++ b/examples/src/one-rect/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.12.8"}
-pax-std = { version = "0.12.8"}
-pax-compiler = { version = "0.12.8", optional = true}
-pax-manifest = { version = "0.12.8"}
+pax-engine = { version = "0.12.8", path = ".pax/pkg/pax-engine" }
+pax-std = { version = "0.12.8", path = ".pax/pkg/pax-std" }
+pax-compiler = { version = "0.12.8", optional = true, path = ".pax/pkg/pax-compiler" }
+pax-manifest = { version = "0.12.8", path = ".pax/pkg/pax-manifest" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -1,5 +1,9 @@
 use pax_manifest::{
-    escape_identifier, ComponentDefinition, ComponentTemplate, ControlFlowRepeatPredicateDefinition, ExpressionCompilationInfo, ExpressionSpec, ExpressionSpecInvocation, HostCrateInfo, PaxManifest, PropertyDefinition, PropertyDefinitionFlags, SettingElement, TemplateNodeId, Token, TypeDefinition, TypeId, TypeTable, ValueDefinition
+    escape_identifier, ComponentDefinition, ComponentTemplate,
+    ControlFlowRepeatPredicateDefinition, ExpressionCompilationInfo, ExpressionSpec,
+    ExpressionSpecInvocation, HostCrateInfo, PaxManifest, PropertyDefinition,
+    PropertyDefinitionFlags, SettingElement, TemplateNodeId, Token, TypeDefinition, TypeId,
+    TypeTable, ValueDefinition,
 };
 use std::collections::HashMap;
 use std::ops::RangeFrom;
@@ -154,12 +158,18 @@ fn recurse_compile_literal_block<'a>(
                     );
 
                     //Write this expression compilation info back to the manifest, for downstream use by RIL component tree generator
-                    let dependencies = invocations.iter().map(|i| i.root_identifier.clone()).collect::<Vec<String>>();
-                    let mut expression_compilation_insert = Some(ExpressionCompilationInfo{
+                    let dependencies = invocations
+                        .iter()
+                        .map(|i| i.root_identifier.clone())
+                        .collect::<Vec<String>>();
+                    let mut expression_compilation_insert = Some(ExpressionCompilationInfo {
                         vtable_id: id,
                         dependencies,
                     });
-                    std::mem::swap(expression_compilation_info, &mut expression_compilation_insert);
+                    std::mem::swap(
+                        expression_compilation_info,
+                        &mut expression_compilation_insert,
+                    );
                 }
                 ValueDefinition::Identifier(identifier, expression_compilation_info) => {
                     // e.g. the self.active_color in `bg_color=self.active_color`
@@ -189,12 +199,18 @@ fn recurse_compile_literal_block<'a>(
                             compile_paxel_to_ril(identifier.clone(), &ctx)?;
 
                         //Write this expression compilation info back to the manifest, for downstream use by RIL component tree generator
-                        let dependencies = invocations.iter().map(|i| i.root_identifier.clone()).collect::<Vec<String>>();
-                        let mut expression_compilation_insert = Some(ExpressionCompilationInfo{
+                        let dependencies = invocations
+                            .iter()
+                            .map(|i| i.root_identifier.clone())
+                            .collect::<Vec<String>>();
+                        let mut expression_compilation_insert = Some(ExpressionCompilationInfo {
                             vtable_id: id,
                             dependencies,
                         });
-                        std::mem::swap(expression_compilation_info, &mut expression_compilation_insert);
+                        std::mem::swap(
+                            expression_compilation_info,
+                            &mut expression_compilation_insert,
+                        );
 
                         let source_map_id = source_map.insert(identifier.clone());
                         let input_statement = source_map

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -6,6 +6,8 @@ use pax_runtime::api::*;
 use pax_runtime::*;
 use pax_manifest::deserializer::{from_pax, from_pax_try_intoable_literal};
 use std::cell::Ref;
+use pax_runtime::api::properties::ErasedProperty;
+use pax_runtime::api::properties::Erasable;
 
 const INITAL_MANIFEST: &str = include_str!("../initial-manifest.json");
 
@@ -116,58 +118,84 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
 }
 
 pub trait ComponentFactory {
+
     /// Returns the default CommonProperties factory
-    fn build_default_common_properties(&self) -> Box<dyn Fn() -> Rc<RefCell<CommonProperties>>>{
-        Box::new(|| Rc::new(RefCell::new(CommonProperties::default())))    
+    fn build_default_common_properties(&self) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>>{
+        Box::new(|_,_| Rc::new(RefCell::new(CommonProperties::default())))    
     }
 
     /// Returns the default properties factory for this component
-    fn build_default_properties(&self) -> Box<dyn Fn() -> Rc<RefCell<dyn Any>>>;
+    fn build_default_properties(&self) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>;
     
     /// Returns the CommonProperties factory based on the defined properties 
-    fn build_inline_common_properties(&self, defined_properties: &HashMap<String,ValueDefinition>) ->Box<dyn Fn() -> Rc<RefCell<CommonProperties>>> {
-        let mut cp = CommonProperties::default();
-        for (key, value) in defined_properties {
-            match key.as_str() {
-                {% for common_property in common_properties %}
-                "{{common_property.name}}" => {
-                    let resolved_property: Property<{{common_property.property_type._type_id}}> = match value.clone() {
-                        ValueDefinition::LiteralValue(lv) => {
-                            {% if common_property.property_type.is_intoable_downstream_type %}
-                                let mi = from_pax_try_intoable_literal(&lv.raw_value);
-                                if let Ok(intoable_literal) = mi {
-                                    Property::new(intoable_literal.into())
-                                } else {
+    fn build_inline_common_properties(&self, defined_properties: HashMap<String,ValueDefinition>) ->Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>> {
+        Box::new(move |stack_frame , table | Rc::new(RefCell::new({
+            let mut cp = CommonProperties::default();
+            for (key, value) in &defined_properties {
+                match key.as_str() {
+                    {% for common_property in common_properties %}
+                    "{{common_property.name}}" => {
+                        let resolved_property: Property<{{common_property.property_type._type_id}}> = match value.clone() {
+                            ValueDefinition::LiteralValue(lv) => {
+                                {% if common_property.property_type.is_intoable_downstream_type %}
+                                    let mi = from_pax_try_intoable_literal(&lv.raw_value);
+                                    if let Ok(intoable_literal) = mi {
+                                        Property::new(intoable_literal.into())
+                                    } else {
+                                        Property::new(from_pax::<{{common_property.property_type._type_id}}>(&lv.raw_value).unwrap().into())
+                                    }
+                                {% else %}
                                     Property::new(from_pax::<{{common_property.property_type._type_id}}>(&lv.raw_value).unwrap().into())
+                                {% endif %}
+                            },
+                            ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token,info) =>
+                            {
+                                if let Some(info) = info {
+                                    let mut dependents = vec![];
+                                    for dependency in &info.dependencies {
+                                        if let Some(p) = stack_frame.resolve_symbol_as_erased_property(dependency) {
+                                            dependents.push(p);
+                                        } else {
+                                            panic!("Failed to resolve symbol {}", dependency);
+                                        }
+                                    }
+                                    let cloned_stack = stack_frame.clone();
+                                    let cloned_table = table.clone();
+                                    Property::computed(move || {
+                                        let new_value_wrapped: Box<dyn Any> = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
+                                        if let Ok(downcast_value) = new_value_wrapped.downcast::<{{common_property.property_type._type_id}}>() {
+                                            *downcast_value
+                                        } else {
+                                            panic!(
+                                                "property has an unexpected type for vtable id {}",
+                                                info.vtable_id
+                                            );
+                                        }
+                                    
+                                    }, &dependents)
+                                } else {
+                                    unreachable!("No info for expression")
                                 }
-                            {% else %}
-                                Property::new(from_pax::<{{common_property.property_type._type_id}}>(&lv.raw_value).unwrap().into())
-                            {% endif %}
-                        },
-                        ValueDefinition::Expression(token, id) | ValueDefinition::Identifier(token,id) =>
-                        {
-                            Property::computed(|| Default::default(), &[]) // TODODAG insert actual logic (using vtable, stack, vtable_id)
-                        },
-                        _ => unreachable!("Invalid value definition for {{common_property.name}}")
-                    };
-                    {%if common_property.is_optional %}
-                        cp.{{common_property.name}} = Some(resolved_property)
-                    {% else %}
-                        cp.{{common_property.name}} = resolved_property
-                    {% endif %}
-                },
-                {% endfor %}
-                _ => {}
+                            },
+                            _ => unreachable!("Invalid value definition for {{common_property.name}}")
+                        };
+                        {%if common_property.is_optional %}
+                            cp.{{common_property.name}} = Some(resolved_property)
+                        {% else %}
+                            cp.{{common_property.name}} = resolved_property
+                        {% endif %}
+                    },
+                    {% endfor %}
+                    _ => {}
+                }
             }
-        }
 
-        Box::new(move || Rc::new(RefCell::new({
             cp.clone()
         })))
     }
 
     /// Returns the properties factory based on the defined properties
-    fn build_inline_properties(&self, defined_properties: &HashMap<String,ValueDefinition>) -> Box<dyn Fn() -> Rc<RefCell<dyn Any>>>;
+    fn build_inline_properties(&self, defined_properties: HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>;
     
     /// Returns the requested closure for the handler registry based on the defined handlers for this component
     /// The argument type is extrapolated based on how the handler was used in the initial compiled template
@@ -184,6 +212,11 @@ pub trait ComponentFactory {
     
     // Calls the instantion function for the component
     fn build_component(&self, args: InstantiationArgs) -> Rc<dyn InstanceNode>;
+
+    // Returns the property scope for the component
+    fn get_properties_scope_factory(&self) -> Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>> {
+        Box::new(|_| HashMap::new())
+    }
 }
 
 {% for c in components -%}
@@ -193,11 +226,12 @@ pub trait ComponentFactory {
 trait TypeFactory {
     type Output: Default + Clone;
     
-    fn build_type(&self, args: &LiteralBlockDefinition) -> Self::Output;
+    fn build_type(&self, args: &LiteralBlockDefinition, stack_frame: Rc<RuntimePropertiesStackFrame>, table: Rc<ExpressionTable>) -> Self::Output;
 }
-
 {% for key, value in type_table -%}
         {{ macros::render_type_factory(type_table=type_table, active_type=value) }}
+        {% if value.type_id.pax_type.Singleton %}
+        {% endif %}
 {%- endfor %}
 
 pub struct DefinitionToInstanceTraverser {
@@ -320,14 +354,14 @@ impl DefinitionToInstanceTraverser {
             compute_properties_fn,
             children: None,
             template_node_identifier: None,
-            property_names: Some(property_names),
+            properties_scope_factory: Some(factory.get_properties_scope_factory()),
         }
     }
 
     pub fn build_control_flow(&self, containing_component_type_id: &TypeId, node_id: &TemplateNodeId) -> Rc<dyn InstanceNode> {
 
         let manifest = self.get_manifest();
-        let prototypical_common_properties_factory = Box::new(|| Rc::new(RefCell::new(CommonProperties::default())));
+        let prototypical_common_properties_factory = Box::new(|_,_| Rc::new(RefCell::new(CommonProperties::default())));
 
         let containing_component = manifest.components.get(containing_component_type_id).unwrap();
         let containing_template = containing_component.template.as_ref().unwrap();
@@ -342,9 +376,9 @@ impl DefinitionToInstanceTraverser {
                     .unwrap()
                     .condition_expression_vtable_id
                     .unwrap();
-                let prototypical_properties_factory : Box<dyn Fn() -> Rc<RefCell<dyn Any>>>  = Box::new(move || Rc::new(RefCell::new( {
+                let prototypical_properties_factory : Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> = Box::new(move |_,_| Rc::new(RefCell::new( {
                         let mut properties = ConditionalProperties::default();
-                        properties.boolean_expression = Property::computed(|| true, &[]); // TODODAG insert actual logic
+                        properties.boolean_expression = Property::computed(|| true, &Vec::new()); // TODODAG insert actual logic
                         properties
                     })));
                 ConditionalInstance::instantiate(InstantiationArgs {
@@ -355,7 +389,7 @@ impl DefinitionToInstanceTraverser {
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
                     template_node_identifier: Some(unique_identifier),
-                    property_names: None,
+                    properties_scope_factory: None,
                 })
             },
             PaxType::Slot => {
@@ -365,9 +399,9 @@ impl DefinitionToInstanceTraverser {
                     .unwrap()
                     .slot_index_expression_vtable_id
                     .unwrap();
-                let prototypical_properties_factory : Box<dyn Fn() -> Rc<RefCell<dyn Any>>>  = Box::new(move || Rc::new(RefCell::new( {
+                let prototypical_properties_factory : Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>  = Box::new(move |_,_| Rc::new(RefCell::new( {
                         let mut properties = SlotProperties::default();
-                        properties.index = Property::computed(|| Default::default(), &[]); // TODODAG insert actual logic (using vtable, stack, vtable_id)
+                        properties.index = Property::computed(|| Default::default(), &Vec::new()); // TODODAG insert actual logic (using vtable, stack, vtable_id)
                         properties
                     })));
                 SlotInstance::instantiate(InstantiationArgs {
@@ -378,7 +412,7 @@ impl DefinitionToInstanceTraverser {
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
                     template_node_identifier: Some(unique_identifier),
-                    property_names: None,
+                    properties_scope_factory: None,
                 })
             },
             PaxType::Repeat => {
@@ -396,19 +430,18 @@ impl DefinitionToInstanceTraverser {
                     .repeat_predicate_definition
                     .clone()
                     .unwrap();
-                let symbols = rpd.get_symbols();
                 let vtable_id = rsd.vtable_id.unwrap();
-                let prototypical_properties_factory : Box<dyn Fn() -> Rc<RefCell<dyn Any>>>  = Box::new(move || Rc::new(RefCell::new( {
+                let prototypical_properties_factory : Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> = Box::new(move |_,_| Rc::new(RefCell::new( {
                         let mut properties = RepeatProperties::default();
                         properties.source_expression_vec = 
                             if let Some(t) = &rsd.symbolic_binding {
-                                Some(Property::computed(|| Default::default(), &[])) // TODODAG
+                                Some(Property::computed(|| Default::default(),  &Vec::new())) // TODODAG
                             } else {
                                 None
                             };
                         properties.source_expression_range =
                             if let Some(t) = &rsd.range_expression_paxel {
-                                Some(Property::computed(|| Default::default(), &[])) // TODODAG
+                                Some(Property::computed(|| Default::default(),  &Vec::new())) // TODODAG
                             } else {
                                 None
                             };
@@ -422,7 +455,7 @@ impl DefinitionToInstanceTraverser {
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
                     template_node_identifier: Some(unique_identifier),
-                    property_names: Some(symbols)
+                    properties_scope_factory: None
                 })
             },
             _ => {  
@@ -478,16 +511,17 @@ impl DefinitionToInstanceTraverser {
 
         // update properties from tnd 
         let inline_properties = manifest.get_inline_properties(containing_component_type_id, node);
-        let updated_properties = node_component_factory.build_inline_properties(&inline_properties);
+        let updated_properties = node_component_factory.build_inline_properties(inline_properties.clone());
         args.prototypical_properties_factory = updated_properties;
 
         // update common properties from tnd
-        let updated_common_properties = node_component_factory.build_inline_common_properties(&inline_properties);
+        let updated_common_properties = node_component_factory.build_inline_common_properties(inline_properties);
         args.prototypical_common_properties_factory = updated_common_properties;
 
        
         args.children = Some(RefCell::new(self.build_children(containing_component_type_id, node_id)));
         args.template_node_identifier = Some(UniqueTemplateNodeIdentifier::build(containing_component_type_id.clone(), node_id.clone()));
+
         node_component_factory.build_component(args)
     }
 

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -27,7 +27,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
         {% for invocation in expression_spec.invocations %}
             let {{ invocation.escaped_identifier }} =
             {
-                let properties = if let Some(sf) = ec.stack_frame.peek_nth({{ invocation.stack_offset }}) {
+                let properties = if let Some(sf) = ec.stack_frame.resolve_symbol("{{ invocation.root_identifier }}") {
                     Rc::clone(&sf)
                 } else {
                     panic!("{{ invocation.escaped_identifier }} didn't have an {{ invocation.stack_offset }}th stackframe");
@@ -275,8 +275,8 @@ impl DefinitionToInstanceTraverser {
     }
 
     pub fn build_component_args(&self, type_id: &TypeId) -> InstantiationArgs {
-
         let manifest = self.get_manifest();
+        let property_names = manifest.get_all_property_names(type_id);
         if let None = manifest.components.get(type_id) {
             panic!("Components with type_id {} not found in manifest", type_id);
         }
@@ -320,6 +320,7 @@ impl DefinitionToInstanceTraverser {
             compute_properties_fn,
             children: None,
             template_node_identifier: None,
+            property_names: Some(property_names),
         }
     }
 
@@ -353,7 +354,8 @@ impl DefinitionToInstanceTraverser {
                     component_template: None,
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
-                    template_node_identifier: Some(unique_identifier)
+                    template_node_identifier: Some(unique_identifier),
+                    property_names: None,
                 })
             },
             PaxType::Slot => {
@@ -375,7 +377,8 @@ impl DefinitionToInstanceTraverser {
                     component_template: None,
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
-                    template_node_identifier: Some(unique_identifier)
+                    template_node_identifier: Some(unique_identifier),
+                    property_names: None,
                 })
             },
             PaxType::Repeat => {
@@ -386,6 +389,14 @@ impl DefinitionToInstanceTraverser {
                     .repeat_source_definition
                     .clone()
                     .unwrap();
+                let rpd = tnd
+                    .control_flow_settings
+                    .as_ref()
+                    .unwrap()
+                    .repeat_predicate_definition
+                    .clone()
+                    .unwrap();
+                let symbols = rpd.get_symbols();
                 let vtable_id = rsd.vtable_id.unwrap();
                 let prototypical_properties_factory : Box<dyn Fn() -> Rc<RefCell<dyn Any>>>  = Box::new(move || Rc::new(RefCell::new( {
                         let mut properties = RepeatProperties::default();
@@ -410,7 +421,8 @@ impl DefinitionToInstanceTraverser {
                     component_template: None,
                     compute_properties_fn: None,
                     children: Some(RefCell::new(children)),
-                    template_node_identifier: Some(unique_identifier)
+                    template_node_identifier: Some(unique_identifier),
+                    property_names: Some(symbols)
                 })
             },
             _ => {  

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -3,12 +3,12 @@ struct {{component.pascal_identifier}}Factory{}
 
 impl ComponentFactory for {{component.pascal_identifier}}Factory {
 
-    fn build_default_properties(&self) -> Box<dyn Fn() -> Rc<RefCell<dyn Any>>> {
-        Box::new(|| Rc::new(RefCell::new({{component.pascal_identifier}}::default())))
+    fn build_default_properties(&self) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> {
+        Box::new(|_,_| Rc::new(RefCell::new({{component.pascal_identifier}}::default())))
     }
 
-    fn build_inline_properties(&self, defined_properties: &HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> {
-        Box::new(|stackframe , expression_table | Rc::new(RefCell::new(
+    fn build_inline_properties(&self, defined_properties: HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> {
+        Box::new(move |stack_frame , table | Rc::new(RefCell::new(
             {
         let mut properties = {{component.pascal_identifier}}::default();
         {% for property in component.properties %}
@@ -27,12 +27,37 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                                 Property::new(from_pax::<{{property.property_type.type_id._type_id}}>(&lv.raw_value).unwrap().into())
                             {% endif %}
                         },
-                        ValueDefinition::Expression(token, id) | ValueDefinition::Identifier(token,id) =>
+                        ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token,info) =>
                         {
-                            Property::computed(|| Default::default(), &[]) // TODODAG insert actual logic (using vtable, stack, vtable_id)
+                            if let Some(info) = info {
+                                let mut dependents = vec![];
+                                for dependency in &info.dependencies {
+                                    if let Some(p) = stack_frame.resolve_symbol_as_erased_property(dependency) {
+                                        dependents.push(p);
+                                    } else {
+                                        panic!("Failed to resolve symbol {}", dependency);
+                                    }
+                                }
+                                let cloned_stack = stack_frame.clone();
+                                let cloned_table = table.clone();
+                                Property::computed(move || {
+                                    let new_value_wrapped: Box<dyn Any> = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
+                                    if let Ok(downcast_value) = new_value_wrapped.downcast::<{{property.property_type.type_id._type_id}}>() {
+                                        *downcast_value
+                                    } else {
+                                        panic!(
+                                            "property has an unexpected type for vtable id {}",
+                                            info.vtable_id
+                                        );
+                                    }
+                                
+                                }, &dependents)
+                            } else {
+                                unreachable!("No info for expression")
+                            }
                         },
                         ValueDefinition::Block(block) => {
-                            Property::new({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block))
+                            Property::new({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone(), table.clone()))
                         }
                         _ => unreachable!("Invalid value definition for {{property.name}}")
                     };
@@ -134,6 +159,22 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
         ComponentInstance::instantiate(args)
         {% endif %}    
     }
+
+    fn get_properties_scope_factory(&self) -> Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>>  {
+        Box::new(|props| {
+            let properties = &mut props.as_ref().borrow_mut();
+            if let Some(properties) = properties.downcast_mut::<{{component.pascal_identifier}}>() {
+                let mut scope = HashMap::new();
+                {% for prop in component.properties %}
+                    scope.insert("{{prop.name}}".to_string(), properties.{{prop.name}}.erase());
+                {% endfor %}
+                scope
+            } else {
+                panic!("Failed to downcast properties to {{component.pascal_identifier}}");
+            }
+        })
+    }
+
 }
 {%- endmacro -%}
 
@@ -145,7 +186,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
 
     type Output={{active_type.type_id._type_id}};
 
-    fn build_type(&self, args: &LiteralBlockDefinition) -> Self::Output {
+    fn build_type(&self, args: &LiteralBlockDefinition, stack_frame: Rc<RuntimePropertiesStackFrame>, table: Rc<ExpressionTable>) -> Self::Output {
         let mut properties: {{active_type.type_id._type_id}} = Default::default();
         for setting in &args.elements {
             if let SettingElement::Setting(k, vd) = setting {
@@ -173,13 +214,38 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                             Property::new(from_pax::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap())
                                         {% endif %}
                                     },
-                                    ValueDefinition::Expression(token, id) | ValueDefinition::Identifier(token,id) =>
+                                    ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token, info ) =>
                                     {
-                                        //Property::new(id.expect("Tried to use expression but it wasn't compiled"))
-                                        Property::new(Default::default())
+                                        if let Some(info) = info {
+                                            let mut dependents = vec![];
+                                            for dependency in &info.dependencies {
+                                                if let Some(p) = stack_frame.resolve_symbol_as_erased_property(dependency) {
+                                                    dependents.push(p);
+                                                } else {
+                                                    panic!("Failed to resolve symbol {}", dependency);
+                                                }
+                                            }
+                                            let cloned_stack = stack_frame.clone();
+                                            let cloned_table = table.clone();
+                                            let cloned_info = info.clone();
+                                            Property::computed(move || {
+                                                let new_value_wrapped: Box<dyn Any> = cloned_table.compute_vtable_value(&cloned_stack, cloned_info.vtable_id);
+                                                if let Ok(downcast_value) = new_value_wrapped.downcast::<{{prop.type_id._type_id}}>() {
+                                                    *downcast_value
+                                                } else {
+                                                    panic!(
+                                                        "property has an unexpected type for vtable id {}",
+                                                        cloned_info.vtable_id
+                                                    );
+                                                }
+                                            
+                                            }, &dependents)
+                                        } else {
+                                            unreachable!("No info for expression")
+                                        }
                                     },
                                     ValueDefinition::Block(block) => {
-                                        Property::new({{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(&block))
+                                        Property::new({{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone(), table.clone()))
                                     }
                                     _ => unreachable!("Invalid value definition for {{prop.name}}")
                                 };
@@ -199,7 +265,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                         {% endif %}
                                     },
                                     ValueDefinition::Block(block) => {
-                                        {{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(args)
+                                        {{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(args, stack_frame.clone(), table.clone())
                                     }
                                     _ => unreachable!("Invalid value definition for {{prop.name}}")
                                 };

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -7,7 +7,9 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
         Box::new(|| Rc::new(RefCell::new({{component.pascal_identifier}}::default())))
     }
 
-    fn build_inline_properties(&self, defined_properties: &HashMap<String,ValueDefinition>) -> Box<dyn Fn() -> Rc<RefCell<dyn Any>>> {
+    fn build_inline_properties(&self, defined_properties: &HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>> {
+        Box::new(|stackframe , expression_table | Rc::new(RefCell::new(
+            {
         let mut properties = {{component.pascal_identifier}}::default();
         {% for property in component.properties %}
             if let Some(vd) = defined_properties.get("{{property.name}}") {
@@ -36,9 +38,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                     };
             }
         {% endfor %}
-        Box::new(move || Rc::new(RefCell::new(
-        {
-            properties.clone()
+        properties
         })))
     }
 

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -13,7 +13,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
         let mut properties = {{component.pascal_identifier}}::default();
         {% for property in component.properties %}
             if let Some(vd) = defined_properties.get("{{property.name}}") {
-                properties.{{property.name}} =
+                properties.{{property.name}}.replace_with(
                     match vd.clone() {
                         ValueDefinition::LiteralValue(lv) => {
                             {% if property.property_type.type_id.is_intoable_downstream_type %}
@@ -60,7 +60,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                             Property::new({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone(), table.clone()))
                         }
                         _ => unreachable!("Invalid value definition for {{property.name}}")
-                    };
+                    });
             }
         {% endfor %}
         properties

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -77,8 +77,7 @@ impl PaxManifest {
                 ret.insert(prop.name.clone());
             });
         ret
-    }    
-
+    }
 }
 
 pub fn get_common_properties_type_ids() -> Vec<TypeId> {
@@ -116,7 +115,6 @@ pub fn get_common_properties_as_property_definitions() -> Vec<PropertyDefinition
     }
     ret
 }
-
 
 impl Eq for ExpressionSpec {}
 
@@ -1197,7 +1195,10 @@ impl ComponentTemplate {
     }
 
     /// Given a list of known expressions, this function will update the expression ids in the template
-    pub fn update_expression_ids(&mut self, known_expressions: &HashMap<String, ExpressionCompilationInfo>) {
+    pub fn update_expression_ids(
+        &mut self,
+        known_expressions: &HashMap<String, ExpressionCompilationInfo>,
+    ) {
         for (_, tnd) in self.nodes.iter_mut() {
             if let Some(settings) = &mut tnd.settings {
                 for setting in settings {
@@ -1457,14 +1458,12 @@ impl TypeDefinition {
     }
 }
 
-
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 pub struct ExpressionCompilationInfo {
     pub vtable_id: usize,
     /// symbols used in the expression
     pub dependencies: Vec<String>,
 }
-
 
 /// Container for settings values, storing all possible
 /// variants, populated at parse-time and used at compile-time
@@ -1576,13 +1575,15 @@ pub enum ControlFlowRepeatPredicateDefinition {
 }
 
 impl ControlFlowRepeatPredicateDefinition {
-    pub fn get_symbols(&self) -> HashSet<String>{
+    pub fn get_symbols(&self) -> HashSet<String> {
         match self {
             ControlFlowRepeatPredicateDefinition::ElemId(t) => {
                 vec![t.raw_value.clone()].into_iter().collect()
             }
             ControlFlowRepeatPredicateDefinition::ElemIdIndexId(t1, t2) => {
-                vec![t1.raw_value.clone(), t2.raw_value.clone()].into_iter().collect()
+                vec![t1.raw_value.clone(), t2.raw_value.clone()]
+                    .into_iter()
+                    .collect()
             }
         }
     }
@@ -1601,7 +1602,6 @@ pub struct ControlFlowSettingsDefinition {
     pub repeat_predicate_definition: Option<ControlFlowRepeatPredicateDefinition>,
     pub repeat_source_definition: Option<ControlFlowRepeatSourceDefinition>,
 }
-
 
 impl PartialEq for ControlFlowRepeatSourceDefinition {
     fn eq(&self, other: &Self) -> bool {

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -1,10 +1,11 @@
 use std::any::Any;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ops::{Add, Deref, Mul, Neg, Sub};
 
 use crate::math::Space;
 use kurbo::BezPath;
 use piet::PaintBrush;
+use properties::{Erasable, ErasedProperty};
 
 #[cfg(feature = "designtime")]
 use {
@@ -527,6 +528,46 @@ impl CommonProperties {
                 optional: (id.0 == "transform" || id.0 == "width" || id.0 == "height"),
             })
             .collect()
+    }
+
+    pub fn retrieve_property_scope(&self) -> HashMap<String, ErasedProperty> {
+        let mut scope = HashMap::new();
+    
+        if let Some(id) = &self.id {
+            scope.insert("id".to_string(), id.erase());
+        }
+        if let Some(x) = &self.x {
+            scope.insert("x".to_string(), x.erase());
+        }
+        if let Some(y) = &self.y {
+            scope.insert("y".to_string(), y.erase());
+        }
+        if let Some(scale_x) = &self.scale_x {
+            scope.insert("scale_x".to_string(), scale_x.erase());
+        }
+        if let Some(scale_y) = &self.scale_y {
+            scope.insert("scale_y".to_string(), scale_y.erase());
+        }
+        if let Some(skew_x) = &self.skew_x {
+            scope.insert("skew_x".to_string(), skew_x.erase());
+        }
+        if let Some(skew_y) = &self.skew_y {
+            scope.insert("skew_y".to_string(), skew_y.erase());
+        }
+        if let Some(rotate) = &self.rotate {
+            scope.insert("rotate".to_string(), rotate.erase());
+        }
+        if let Some(anchor_x) = &self.anchor_x {
+            scope.insert("anchor_x".to_string(), anchor_x.erase());
+        }
+        if let Some(anchor_y) = &self.anchor_y {
+            scope.insert("anchor_y".to_string(), anchor_y.erase());
+        }
+        scope.insert("transform".to_string(), self.transform.erase());
+        scope.insert("width".to_string(), self.width.erase());
+        scope.insert("height".to_string(), self.height.erase());
+
+        scope
     }
 }
 

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -532,7 +532,7 @@ impl CommonProperties {
 
     pub fn retrieve_property_scope(&self) -> HashMap<String, ErasedProperty> {
         let mut scope = HashMap::new();
-    
+
         if let Some(id) = &self.id {
             scope.insert("id".to_string(), id.erase());
         }

--- a/pax-runtime-api/src/properties.rs
+++ b/pax-runtime-api/src/properties.rs
@@ -94,7 +94,10 @@ impl<T: PropVal> Property<T> {
 
     /// Used by engine to create dependency chains, the evaluator fires and
     /// re-computes a property each time it's dependencies change.
-    pub fn computed(evaluator: impl Fn() -> T + 'static, dependents: &Vec<&ErasedProperty>) -> Self {
+    pub fn computed(
+        evaluator: impl Fn() -> T + 'static,
+        dependents: &Vec<&ErasedProperty>,
+    ) -> Self {
         let dependent_property_ids: Vec<_> = dependents.iter().map(|v| v.get_id()).collect();
         let id = glob_prop_table(|t| {
             t.add_expr_entry(
@@ -378,7 +381,6 @@ enum PropType {
     },
 }
 
-
 #[derive(Debug, Clone)]
 pub struct ErasedProperty {
     id: PropId,
@@ -406,7 +408,6 @@ impl<T> Erasable for Property<T> {
         ErasedProperty { id: self.id }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -78,7 +78,9 @@ impl InstanceNode for ComponentInstance {
                 Some(containing_component.create_children_detached(children_with_env, context));
         }
         let properties_scope = expanded_node.properties_scope.borrow();
-        let new_env = expanded_node.stack.push(properties_scope.clone(), &expanded_node.properties.borrow());
+        let new_env = expanded_node
+            .stack
+            .push(properties_scope.clone(), &expanded_node.properties.borrow());
         let children = self.template.borrow();
         let children_with_envs = children.iter().cloned().zip(iter::repeat(new_env));
         expanded_node.set_children(children_with_envs, context);

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -77,8 +77,8 @@ impl InstanceNode for ComponentInstance {
             *expanded_node.expanded_slot_children.borrow_mut() =
                 Some(containing_component.create_children_detached(children_with_env, context));
         }
-        let property_names = expanded_node.instance_node.borrow().base().property_names.clone().unwrap_or_default();
-        let new_env = expanded_node.stack.push(property_names, &expanded_node.properties.borrow());
+        let properties_scope = expanded_node.properties_scope.borrow();
+        let new_env = expanded_node.stack.push(properties_scope.clone(), &expanded_node.properties.borrow());
         let children = self.template.borrow();
         let children_with_envs = children.iter().cloned().zip(iter::repeat(new_env));
         expanded_node.set_children(children_with_envs, context);

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::rc::Rc;
 use std::{cell::RefCell, iter};
 
@@ -53,7 +54,7 @@ impl InstanceNode for ComponentInstance {
         // Compute properties
         (*self.compute_properties_fn)(
             &expanded_node,
-            context.expression_table(),
+            context.expression_table().borrow(),
             context.globals(),
         );
 

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -76,8 +76,8 @@ impl InstanceNode for ComponentInstance {
             *expanded_node.expanded_slot_children.borrow_mut() =
                 Some(containing_component.create_children_detached(children_with_env, context));
         }
-
-        let new_env = expanded_node.stack.push(&expanded_node.properties.borrow());
+        let property_names = expanded_node.instance_node.borrow().base().property_names.clone().unwrap_or_default();
+        let new_env = expanded_node.stack.push(property_names, &expanded_node.properties.borrow());
         let children = self.template.borrow();
         let children_with_envs = children.iter().cloned().zip(iter::repeat(new_env));
         expanded_node.set_children(children_with_envs, context);

--- a/pax-runtime/src/conditional.rs
+++ b/pax-runtime/src/conditional.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::{iter, rc::Rc};
 
 use pax_runtime_api::Property;
@@ -46,7 +47,7 @@ impl InstanceNode for ConditionalInstance {
         let (should_update, active) =
             expanded_node.with_properties_unwrapped(|properties: &mut ConditionalProperties| {
                 handle_vtable_update(
-                    context.expression_table(),
+                    context.expression_table().borrow(),
                     &expanded_node.stack,
                     &mut properties.boolean_expression,
                     context.globals(),

--- a/pax-runtime/src/declarative_macros.rs
+++ b/pax-runtime/src/declarative_macros.rs
@@ -10,7 +10,7 @@ use crate::{ExpressionTable, Globals, RuntimePropertiesStackFrame};
 /// handle_vtable_update!(ptc, self.height, Size);
 /// ```
 pub fn handle_vtable_update<V: Default + Clone + Interpolatable + 'static>(
-    table: &ExpressionTable,
+    table: &Rc<ExpressionTable>,
     stack: &Rc<RuntimePropertiesStackFrame>,
     property: &Property<V>,
     globals: &Globals,
@@ -42,7 +42,7 @@ pub fn handle_vtable_update<V: Default + Clone + Interpolatable + 'static>(
 /// handle_vtable_update_optional!(ptc, self.scale_x, Size);
 /// ```
 pub fn handle_vtable_update_optional<V: Default + Clone + Interpolatable + 'static>(
-    table: &ExpressionTable,
+    table: &Rc<ExpressionTable>,
     stack: &Rc<RuntimePropertiesStackFrame>,
     optional_property: Option<&Property<V>>,
     globals: &Globals,

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -159,8 +159,10 @@ macro_rules! dispatch_event_handler {
 
 impl ExpandedNode {
     pub fn root(template: Rc<ComponentInstance>, context: &mut RuntimeContext) -> Rc<Self> {
-        let root_env =
-            RuntimePropertiesStackFrame::new(HashMap::new(), Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>);
+        let root_env = RuntimePropertiesStackFrame::new(
+            HashMap::new(),
+            Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>,
+        );
         let root_node = Self::new(template, root_env, context, Weak::new());
         Rc::clone(&root_node).recurse_mount(context);
         root_node
@@ -172,10 +174,16 @@ impl ExpandedNode {
         context: &mut RuntimeContext,
         containing_component: Weak<ExpandedNode>,
     ) -> Rc<Self> {
-        let properties = (&template.base().instance_prototypical_properties_factory)(env.clone(), context.expression_table());
+        let properties = (&template.base().instance_prototypical_properties_factory)(
+            env.clone(),
+            context.expression_table(),
+        );
         let common_properties = (&template
             .base()
-            .instance_prototypical_common_properties_factory)(env.clone(), context.expression_table());
+            .instance_prototypical_common_properties_factory)(
+            env.clone(),
+            context.expression_table(),
+        );
 
         let mut property_scope = (*common_properties).borrow().retrieve_property_scope();
 
@@ -202,15 +210,23 @@ impl ExpandedNode {
         })
     }
 
-    pub fn recreate_with_new_data(self: &Rc<Self>, template: Rc<dyn InstanceNode>,
-        expression_table: Rc<ExpressionTable>) {
+    pub fn recreate_with_new_data(
+        self: &Rc<Self>,
+        template: Rc<dyn InstanceNode>,
+        expression_table: Rc<ExpressionTable>,
+    ) {
         *self.instance_node.borrow_mut() = Rc::clone(&template);
 
-        *self.properties.borrow_mut() =
-            (&template.base().instance_prototypical_properties_factory)(self.stack.clone(), expression_table.clone());
+        *self.properties.borrow_mut() = (&template.base().instance_prototypical_properties_factory)(
+            self.stack.clone(),
+            expression_table.clone(),
+        );
         *self.common_properties.borrow_mut() = (template
             .base()
-            .instance_prototypical_common_properties_factory)(self.stack.clone(), expression_table.clone());
+            .instance_prototypical_common_properties_factory)(
+            self.stack.clone(),
+            expression_table.clone(),
+        );
     }
 
     /// Returns whether this node is a descendant of the ExpandedNode described by `other_expanded_node_id` (id_chain)
@@ -288,7 +304,11 @@ impl ExpandedNode {
     pub fn recurse_update(self: &Rc<Self>, context: &mut RuntimeContext) {
         self.get_common_properties()
             .borrow_mut()
-            .compute_properties(&self.stack, context.expression_table().borrow(), context.globals());
+            .compute_properties(
+                &self.stack,
+                context.expression_table().borrow(),
+                context.globals(),
+            );
 
         let viewport = self
             .parent_expanded_node
@@ -575,7 +595,7 @@ impl ExpandedNode {
 
     fn retrieve_common_property_scopes(&self) -> HashMap<String, ErasedProperty> {
         let mut scopes = HashMap::new();
-        
+
         scopes
     }
 

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -1,4 +1,5 @@
 use pax_runtime_api::properties::ErasedProperty;
+use pax_runtime_api::Property;
 
 use crate::api::math::Point2;
 use crate::constants::{
@@ -302,13 +303,13 @@ impl ExpandedNode {
     /// This method recursively updates all node properties. When dirty-dag exists, this won't
     /// need to be here since all property dependencies can be set up and removed during mount/unmount
     pub fn recurse_update(self: &Rc<Self>, context: &mut RuntimeContext) {
-        self.get_common_properties()
-            .borrow_mut()
-            .compute_properties(
-                &self.stack,
-                context.expression_table().borrow(),
-                context.globals(),
-            );
+        // self.get_common_properties()
+        //     .borrow_mut()
+        //     .compute_properties(
+        //         &self.stack,
+        //         context.expression_table().borrow(),
+        //         context.globals(),
+        //     );
 
         let viewport = self
             .parent_expanded_node

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -1,3 +1,5 @@
+use pax_runtime_api::properties::ErasedProperty;
+
 use crate::api::math::Point2;
 use crate::constants::{
     BUTTON_CLICK_HANDLERS, CHECKBOX_CHANGE_HANDLERS, CLAP_HANDLERS, CLICK_HANDLERS,
@@ -13,6 +15,7 @@ use core::fmt;
 use std::any::Any;
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
@@ -88,6 +91,10 @@ pub struct ExpandedNode {
     /// Occlusion layer for this node. Used by canvas elements to decide what canvas to draw on, and
     /// by native elements to move to the correct native layer.
     pub occlusion_id: RefCell<u32>,
+
+    /// A map of all properties available on this expanded node.
+    /// Used by the RuntimePropertiesStackFrame to resolve symbols.
+    pub properties_scope: RefCell<HashMap<String, ErasedProperty>>,
 }
 
 macro_rules! dispatch_event_handler {
@@ -152,9 +159,8 @@ macro_rules! dispatch_event_handler {
 
 impl ExpandedNode {
     pub fn root(template: Rc<ComponentInstance>, context: &mut RuntimeContext) -> Rc<Self> {
-        let property_names = template.base().property_names.clone().unwrap_or_default();
         let root_env =
-            RuntimePropertiesStackFrame::new(property_names, Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>);
+            RuntimePropertiesStackFrame::new(HashMap::new(), Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>);
         let root_node = Self::new(template, root_env, context, Weak::new());
         Rc::clone(&root_node).recurse_mount(context);
         root_node
@@ -171,6 +177,12 @@ impl ExpandedNode {
             .base()
             .instance_prototypical_common_properties_factory)(env.clone(), context.expression_table());
 
+        let mut property_scope = (*common_properties).borrow().retrieve_property_scope();
+
+        if let Some(scope) = &template.base().properties_scope_factory {
+            property_scope.extend(scope(properties.clone()));
+        }
+
         Rc::new(ExpandedNode {
             id_chain: vec![context.gen_uid().0],
             instance_node: RefCell::new(Rc::clone(&template)),
@@ -186,6 +198,7 @@ impl ExpandedNode {
             expanded_slot_children: Default::default(),
             expanded_and_flattened_slot_children: Default::default(),
             occlusion_id: RefCell::new(0),
+            properties_scope: RefCell::new(property_scope),
         })
     }
 
@@ -558,6 +571,12 @@ impl ExpandedNode {
             *self.expanded_and_flattened_slot_children.borrow_mut() =
                 Some(flatten_expanded_nodes_for_slot(&slot_children));
         }
+    }
+
+    fn retrieve_common_property_scopes(&self) -> HashMap<String, ErasedProperty> {
+        let mut scopes = HashMap::new();
+        
+        scopes
     }
 
     dispatch_event_handler!(dispatch_scroll, Scroll, SCROLL_HANDLERS, true);

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -7,11 +7,13 @@ use crate::constants::{
     TEXTBOX_INPUT_HANDLERS, TOUCH_END_HANDLERS, TOUCH_MOVE_HANDLERS, TOUCH_START_HANDLERS,
     WHEEL_HANDLERS,
 };
-use crate::Globals;
+use crate::{ExpressionTable, Globals};
 #[cfg(debug_assertions)]
 use core::fmt;
 use std::any::Any;
+use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
 use crate::api::{
@@ -164,10 +166,10 @@ impl ExpandedNode {
         context: &mut RuntimeContext,
         containing_component: Weak<ExpandedNode>,
     ) -> Rc<Self> {
-        let properties = (&template.base().instance_prototypical_properties_factory)();
+        let properties = (&template.base().instance_prototypical_properties_factory)(env.clone(), context.expression_table());
         let common_properties = (&template
             .base()
-            .instance_prototypical_common_properties_factory)();
+            .instance_prototypical_common_properties_factory)(env.clone(), context.expression_table());
 
         Rc::new(ExpandedNode {
             id_chain: vec![context.gen_uid().0],
@@ -187,15 +189,15 @@ impl ExpandedNode {
         })
     }
 
-    pub fn recreate_with_new_data(self: &Rc<Self>, template: Rc<dyn InstanceNode>) {
+    pub fn recreate_with_new_data(self: &Rc<Self>, template: Rc<dyn InstanceNode>,
+        expression_table: Rc<ExpressionTable>) {
         *self.instance_node.borrow_mut() = Rc::clone(&template);
 
         *self.properties.borrow_mut() =
-            (&template.base().instance_prototypical_properties_factory)();
+            (&template.base().instance_prototypical_properties_factory)(self.stack.clone(), expression_table.clone());
         *self.common_properties.borrow_mut() = (template
             .base()
-            .instance_prototypical_common_properties_factory)(
-        );
+            .instance_prototypical_common_properties_factory)(self.stack.clone(), expression_table.clone());
     }
 
     /// Returns whether this node is a descendant of the ExpandedNode described by `other_expanded_node_id` (id_chain)
@@ -273,7 +275,7 @@ impl ExpandedNode {
     pub fn recurse_update(self: &Rc<Self>, context: &mut RuntimeContext) {
         self.get_common_properties()
             .borrow_mut()
-            .compute_properties(&self.stack, context.expression_table(), context.globals());
+            .compute_properties(&self.stack, context.expression_table().borrow(), context.globals());
 
         let viewport = self
             .parent_expanded_node
@@ -291,6 +293,7 @@ impl ExpandedNode {
 
         if let Some(ref registry) = self.instance_node.borrow().base().handler_registry {
             for handler in registry
+                .deref()
                 .borrow()
                 .handlers
                 .get("tick")
@@ -312,6 +315,7 @@ impl ExpandedNode {
         }
         if let Some(ref registry) = self.instance_node.borrow().base().handler_registry {
             for handler in registry
+                .deref()
                 .borrow()
                 .handlers
                 .get("pre_render")
@@ -361,6 +365,7 @@ impl ExpandedNode {
             Rc::clone(&self.instance_node.borrow()).update(&self, context);
             if let Some(ref registry) = self.instance_node.borrow().base().handler_registry {
                 for handler in registry
+                    .deref()
                     .borrow()
                     .handlers
                     .get("mount")

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -150,8 +150,9 @@ macro_rules! dispatch_event_handler {
 
 impl ExpandedNode {
     pub fn root(template: Rc<ComponentInstance>, context: &mut RuntimeContext) -> Rc<Self> {
+        let property_names = template.base().property_names.clone().unwrap_or_default();
         let root_env =
-            RuntimePropertiesStackFrame::new(Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>);
+            RuntimePropertiesStackFrame::new(property_names, Rc::new(RefCell::new(())) as Rc<RefCell<dyn Any>>);
         let root_node = Self::new(template, root_env, context, Weak::new());
         Rc::clone(&root_node).recurse_mount(context);
         root_node

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -56,7 +56,7 @@ pub trait PropertiesComputable {
     fn compute_properties(
         &mut self,
         stack: &Rc<RuntimePropertiesStackFrame>,
-        table: &ExpressionTable,
+        table: &Rc<ExpressionTable>,
         globals: &Globals,
     );
 }
@@ -65,7 +65,7 @@ impl PropertiesComputable for CommonProperties {
     fn compute_properties(
         &mut self,
         stack: &Rc<RuntimePropertiesStackFrame>,
-        table: &ExpressionTable,
+        table: &Rc<ExpressionTable>,
         globals: &Globals,
     ) {
         handle_vtable_update(table, stack, &mut self.width, globals);

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -426,7 +426,7 @@ impl PaxEngine {
             .runtime_context
             .get_expanded_nodes_by_global_ids(&unique_id);
         for node in nodes {
-            node.recreate_with_new_data(new_instance.clone());
+            node.recreate_with_new_data(new_instance.clone(), self.runtime_context.expression_table());
         }
     }
 

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -426,7 +426,10 @@ impl PaxEngine {
             .runtime_context
             .get_expanded_nodes_by_global_ids(&unique_id);
         for node in nodes {
-            node.recreate_with_new_data(new_instance.clone(), self.runtime_context.expression_table());
+            node.recreate_with_new_data(
+                new_instance.clone(),
+                self.runtime_context.expression_table(),
+            );
         }
     }
 

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -164,8 +164,8 @@ impl RuntimeContext {
         &mut self.globals
     }
 
-    pub fn expression_table(&self) -> &ExpressionTable {
-        &self.expression_table
+    pub fn expression_table(&self) -> Rc<ExpressionTable> {
+        self.expression_table.clone()
     }
 }
 

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -185,7 +185,10 @@ pub struct RuntimePropertiesStackFrame {
 }
 
 impl RuntimePropertiesStackFrame {
-    pub fn new(symbols_within_frame: HashMap<String, ErasedProperty>, properties: Rc<RefCell<dyn Any>>) -> Rc<Self> {
+    pub fn new(
+        symbols_within_frame: HashMap<String, ErasedProperty>,
+        properties: Rc<RefCell<dyn Any>>,
+    ) -> Rc<Self> {
         Rc::new(Self {
             symbols_within_frame,
             properties,
@@ -193,7 +196,11 @@ impl RuntimePropertiesStackFrame {
         })
     }
 
-    pub fn push(self: &Rc<Self>, symbols_within_frame: HashMap<String, ErasedProperty>, properties: &Rc<RefCell<dyn Any>>) -> Rc<Self> {
+    pub fn push(
+        self: &Rc<Self>,
+        symbols_within_frame: HashMap<String, ErasedProperty>,
+        properties: &Rc<RefCell<dyn Any>>,
+    ) -> Rc<Self> {
         Rc::new(RuntimePropertiesStackFrame {
             symbols_within_frame,
             parent: Some(Rc::clone(&self)),
@@ -228,7 +235,9 @@ impl RuntimePropertiesStackFrame {
         if let Some(e) = self.symbols_within_frame.get(symbol) {
             Some(e)
         } else {
-            self.parent.as_ref()?.resolve_symbol_as_erased_property(symbol)
+            self.parent
+                .as_ref()?
+                .resolve_symbol_as_erased_property(symbol)
         }
     }
 

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -15,7 +15,10 @@ use piet::{Color, StrokeStyle};
 
 use crate::api::{Layer, Scroll, Size};
 
-use crate::{ExpandedNode, ExpressionTable, Globals, HandlerRegistry, RuntimeContext, RuntimePropertiesStackFrame};
+use crate::{
+    ExpandedNode, ExpressionTable, Globals, HandlerRegistry, RuntimeContext,
+    RuntimePropertiesStackFrame,
+};
 
 /// Type aliases to make it easier to work with nested Rcs and
 /// RefCells for instance nodes.
@@ -23,8 +26,14 @@ pub type InstanceNodePtr = Rc<dyn InstanceNode>;
 pub type InstanceNodePtrList = RefCell<Vec<InstanceNodePtr>>;
 
 pub struct InstantiationArgs {
-    pub prototypical_common_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>>,
-    pub prototypical_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
+    pub prototypical_common_properties_factory: Box<
+        dyn Fn(
+            Rc<RuntimePropertiesStackFrame>,
+            Rc<ExpressionTable>,
+        ) -> Rc<RefCell<CommonProperties>>,
+    >,
+    pub prototypical_properties_factory:
+        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
     pub children: Option<InstanceNodePtrList>,
     pub component_template: Option<InstanceNodePtrList>,
@@ -36,7 +45,8 @@ pub struct InstantiationArgs {
     pub template_node_identifier: Option<UniqueTemplateNodeIdentifier>,
 
     // Used by RuntimePropertyStackFrame to pull out struct's properties based on their names
-    pub properties_scope_factory: Option<Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>>>
+    pub properties_scope_factory:
+        Option<Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>>>,
 }
 
 /// Stores the computed transform and the pre-transform bounding box (where the
@@ -252,11 +262,17 @@ pub trait InstanceNode {
 
 pub struct BaseInstance {
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
-    pub instance_prototypical_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
-    pub instance_prototypical_common_properties_factory:
-        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>>,
+    pub instance_prototypical_properties_factory:
+        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
+    pub instance_prototypical_common_properties_factory: Box<
+        dyn Fn(
+            Rc<RuntimePropertiesStackFrame>,
+            Rc<ExpressionTable>,
+        ) -> Rc<RefCell<CommonProperties>>,
+    >,
     pub template_node_identifier: Option<UniqueTemplateNodeIdentifier>,
-    pub properties_scope_factory: Option<Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>>>,
+    pub properties_scope_factory:
+        Option<Box<dyn Fn(Rc<RefCell<dyn Any>>) -> HashMap<String, ErasedProperty>>>,
     instance_children: InstanceNodePtrList,
     flags: InstanceFlags,
 }

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -14,7 +14,7 @@ use piet::{Color, StrokeStyle};
 
 use crate::api::{Layer, Scroll, Size};
 
-use crate::{ExpandedNode, ExpressionTable, Globals, HandlerRegistry, RuntimeContext};
+use crate::{ExpandedNode, ExpressionTable, Globals, HandlerRegistry, RuntimeContext, RuntimePropertiesStackFrame};
 
 /// Type aliases to make it easier to work with nested Rcs and
 /// RefCells for instance nodes.
@@ -22,8 +22,8 @@ pub type InstanceNodePtr = Rc<dyn InstanceNode>;
 pub type InstanceNodePtrList = RefCell<Vec<InstanceNodePtr>>;
 
 pub struct InstantiationArgs {
-    pub prototypical_common_properties_factory: Box<dyn Fn() -> Rc<RefCell<CommonProperties>>>,
-    pub prototypical_properties_factory: Box<dyn Fn() -> Rc<RefCell<dyn Any>>>,
+    pub prototypical_common_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>>,
+    pub prototypical_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
     pub children: Option<InstanceNodePtrList>,
     pub component_template: Option<InstanceNodePtrList>,
@@ -251,9 +251,9 @@ pub trait InstanceNode {
 
 pub struct BaseInstance {
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
-    pub instance_prototypical_properties_factory: Box<dyn Fn() -> Rc<RefCell<dyn Any>>>,
+    pub instance_prototypical_properties_factory: Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<dyn Any>>>,
     pub instance_prototypical_common_properties_factory:
-        Box<dyn Fn() -> Rc<RefCell<CommonProperties>>>,
+        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>>,
     pub template_node_identifier: Option<UniqueTemplateNodeIdentifier>,
     pub property_names: Option<HashSet<String>>,
     instance_children: InstanceNodePtrList,

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashSet;
 
 use super::api::math::Point2;
 use std::iter;
@@ -32,6 +33,9 @@ pub struct InstantiationArgs {
     pub compute_properties_fn: Option<Box<dyn Fn(&ExpandedNode, &ExpressionTable, &Globals)>>,
 
     pub template_node_identifier: Option<UniqueTemplateNodeIdentifier>,
+
+    // Used by RuntimePropertyStackFrame to determine whether request property is within a properties struct (dyn Any)
+    pub property_names: Option<HashSet<String>>,
 }
 
 /// Stores the computed transform and the pre-transform bounding box (where the
@@ -251,6 +255,7 @@ pub struct BaseInstance {
     pub instance_prototypical_common_properties_factory:
         Box<dyn Fn() -> Rc<RefCell<CommonProperties>>>,
     pub template_node_identifier: Option<UniqueTemplateNodeIdentifier>,
+    pub property_names: Option<HashSet<String>>,
     instance_children: InstanceNodePtrList,
     flags: InstanceFlags,
 }
@@ -283,6 +288,7 @@ impl BaseInstance {
             instance_children: args.children.unwrap_or_default(),
             flags,
             template_node_identifier: args.template_node_identifier,
+            property_names: args.property_names,
         }
     }
 

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -123,8 +123,8 @@ impl InstanceNode for RepeatInstance {
                         i,
                         elem: Rc::clone(&elem),
                     })) as Rc<RefCell<dyn Any>>;
-                    let property_names = expanded_node.instance_node.borrow().base().property_names.clone().unwrap_or_default();
-                    let new_env = expanded_node.stack.push(property_names, &new_repeat_item);
+                    let property_names = expanded_node.properties_scope.borrow();
+                    let new_env = expanded_node.stack.push(property_names.clone(), &new_repeat_item);
                     children
                         .borrow()
                         .clone()

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -122,7 +122,8 @@ impl InstanceNode for RepeatInstance {
                         i,
                         elem: Rc::clone(&elem),
                     })) as Rc<RefCell<dyn Any>>;
-                    let new_env = expanded_node.stack.push(&new_repeat_item);
+                    let property_names = expanded_node.instance_node.borrow().base().property_names.clone().unwrap_or_default();
+                    let new_env = expanded_node.stack.push(property_names, &new_repeat_item);
                     children
                         .borrow()
                         .clone()

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -124,7 +124,9 @@ impl InstanceNode for RepeatInstance {
                         elem: Rc::clone(&elem),
                     })) as Rc<RefCell<dyn Any>>;
                     let property_names = expanded_node.properties_scope.borrow();
-                    let new_env = expanded_node.stack.push(property_names.clone(), &new_repeat_item);
+                    let new_env = expanded_node
+                        .stack
+                        .push(property_names.clone(), &new_repeat_item);
                     children
                         .borrow()
                         .clone()

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::iter;
 use std::rc::Rc;
@@ -70,13 +71,13 @@ impl InstanceNode for RepeatInstance {
         let new_vec =
             expanded_node.with_properties_unwrapped(|properties: &mut RepeatProperties| {
                 handle_vtable_update_optional(
-                    context.expression_table(),
+                    context.expression_table().borrow(),
                     &expanded_node.stack,
                     properties.source_expression_range.as_ref(),
                     context.globals(),
                 );
                 handle_vtable_update_optional(
-                    context.expression_table(),
+                    context.expression_table().borrow(),
                     &expanded_node.stack,
                     properties.source_expression_vec.as_ref(),
                     context.globals(),

--- a/pax-std/pax-std-primitives/src/button.rs
+++ b/pax-std/pax-std-primitives/src/button.rs
@@ -39,7 +39,7 @@ impl InstanceNode for ButtonInstance {
 
     fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, context: &mut RuntimeContext) {
         expanded_node.with_properties_unwrapped(|properties: &mut Button| {
-            let tbl = context.expression_table();
+            let tbl = &context.expression_table();
             let stk = &expanded_node.stack;
             handle_vtable_update(tbl, stk, &mut properties.label, context.globals());
 

--- a/pax-std/pax-std-primitives/src/checkbox.rs
+++ b/pax-std/pax-std-primitives/src/checkbox.rs
@@ -43,7 +43,7 @@ impl InstanceNode for CheckboxInstance {
     fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, context: &mut RuntimeContext) {
         expanded_node.with_properties_unwrapped(|properties: &mut Checkbox| {
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.checked,
                 context.globals(),

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -95,13 +95,13 @@ impl InstanceNode for EllipseInstance {
         //Doesn't need to expand any children
         expanded_node.with_properties_unwrapped(|properties: &mut Ellipse| {
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.stroke,
                 context.globals(),
             );
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.fill,
                 context.globals(),

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -38,7 +38,7 @@ impl InstanceNode for ImageInstance {
         //Doesn't need to expand any children
         expanded_node.with_properties_unwrapped(|properties: &mut Image| {
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.path,
                 context.globals(),

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -35,7 +35,7 @@ impl InstanceNode for PathInstance {
 
     fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, context: &mut RuntimeContext) {
         expanded_node.with_properties_unwrapped(|properties: &mut Path| {
-            let tbl = context.expression_table();
+            let tbl = &context.expression_table();
             let stk = &expanded_node.stack;
             handle_vtable_update(tbl, stk, &mut properties.stroke, context.globals());
             handle_vtable_update(

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -35,31 +35,31 @@ impl InstanceNode for RectangleInstance {
         //Doesn't need to expand any children
         expanded_node.with_properties_unwrapped(|properties: &mut Rectangle| {
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.stroke,
                 context.globals(),
             );
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.stroke.get().color,
                 context.globals(),
             );
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.stroke.get().width,
                 context.globals(),
             );
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.fill,
                 context.globals(),
             );
             handle_vtable_update(
-                context.expression_table(),
+                &context.expression_table(),
                 &expanded_node.stack,
                 &mut properties.corner_radii,
                 context.globals(),

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -41,7 +41,7 @@ impl InstanceNode for TextInstance {
 
     fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, context: &mut RuntimeContext) {
         expanded_node.with_properties_unwrapped(|properties: &mut Text| {
-            let tbl = context.expression_table();
+            let tbl = &context.expression_table();
             let stk = &expanded_node.stack;
             handle_vtable_update(tbl, stk, &mut properties.text, context.globals());
 

--- a/pax-std/pax-std-primitives/src/textbox.rs
+++ b/pax-std/pax-std-primitives/src/textbox.rs
@@ -40,7 +40,7 @@ impl InstanceNode for TextboxInstance {
 
     fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, context: &mut RuntimeContext) {
         expanded_node.with_properties_unwrapped(|properties: &mut Textbox| {
-            let tbl = context.expression_table();
+            let tbl = &context.expression_table();
             let stk = &expanded_node.stack;
             handle_vtable_update(tbl, stk, &mut properties.focus_on_mount, context.globals());
             handle_vtable_update(tbl, stk, &mut properties.text, context.globals());


### PR DESCRIPTION
- Piped through dependencies from expression compilation
- Added resolve_symbol to RuntimePropertyStack
- Updated vtable to use RuntimePropertyStack resolve symbol
- Added ErasedProperty to create type agnostic wrapper of Property<T>
- Added a method a factory to go from property struct Box<dyn Any> -> HashMap<String, ErasedProperty> for resolve scopes
- Hooked up new property system in expression code-gen with replace_with

one-rect example is now running!
Next work is to focus on repeat etc.

Need some more cleaning for replace_with function in property system to generally solve issues we discussed around target property's subtree