### PR TITLE
Factor all literal deserialization to use memoized cache

### DIFF
--- a/pax-manifest/Cargo.toml
+++ b/pax-manifest/Cargo.toml
@@ -20,3 +20,4 @@ pax-runtime-api = {path="../pax-runtime-api", version="0.12.8"}
 pest = { version="2.7.6", optional=true}
 pest_derive = {version="2.7.6", optional=true}
 serde_with = { version= "3.6.1", features = ["json"]} 
+log = "0.4.20"

--- a/pax-manifest/src/deserializer/error.rs
+++ b/pax-manifest/src/deserializer/error.rs
@@ -5,7 +5,7 @@ use serde::{de, ser};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
     Message(String),
 

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -1598,6 +1598,7 @@ impl Transform2D {
 
 // Represents literal types from the deserializer that may need to be `into()` downstream types.
 // For example, 5% might need to be `.into()`d a Rotation, a ColorChannel, or a Size.  Color might need to be `.into()`d a Fill or a Stroke.
+#[derive(Clone)]
 pub enum IntoableLiteral {
     Color(Color),
     Percent(Percent),

--- a/pax-runtime-api/src/properties/mod.rs
+++ b/pax-runtime-api/src/properties/mod.rs
@@ -89,7 +89,9 @@ impl<T: PropertyValue> Property<T> {
     /// expensive in a large reactivity network since this triggers
     /// re-evaluation of dirty property chains
     pub fn get(&self) -> T {
-        PROPERTY_TABLE.with(|t| t.get_value(self.untyped.id))
+        PROPERTY_TABLE.with(|t| {
+            t.get_value(self.untyped.id)
+        })
     }
 
     /// Sets this properties value and sets the drity bit recursively of all of

--- a/pax-runtime-api/src/properties/properties_table.rs
+++ b/pax-runtime-api/src/properties/properties_table.rs
@@ -216,7 +216,7 @@ impl PropertyTable {
         let mut names = self.debug_names.borrow_mut();
         names.insert(
             source_id,
-            format!("{} <repl_with> {}", curr_name, target_name),
+            format!("{}", target_name),
         );
     }
 


### PR DESCRIPTION
To prevent multiple deserializations, we refactor deserialization to use a cached map. This should prevent multiple deserializations, which is currently a decent perf hit on factory usage. Once we do expression interpreting, we can likely host deserialization out of factories completely. 