### PR TITLE
Virtual Scroller

### DIFF
--- a/examples/src/std-scroller/Cargo.toml
+++ b/examples/src/std-scroller/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "std-scroller"
+version = "0.13.1"
+edition = "2021"
+default-run = "run"
+
+[dependencies]
+pax-engine = { version = "0.13.1" , path = ".pax/pkg/pax-engine" }
+pax-std = { version = "0.13.1" , path = ".pax/pkg/pax-std" }
+pax-compiler = { version = "0.13.1", optional = true, path = ".pax/pkg/pax-compiler" }
+pax-manifest = { version = "0.13.1", optional = true, path = ".pax/pkg/pax-manifest" }
+serde_json = {version = "1.0.95", optional = true}
+
+[[bin]]
+name = "parser"
+path = "src/lib.rs"
+required-features = ["parser"]
+
+[[bin]]
+name = "run"
+path = "bin/run.rs"
+
+[features]
+parser = ["pax-std/parser", "pax-engine/parser", "dep:serde_json", "dep:pax-compiler", "dep:pax-manifest"]

--- a/examples/src/std-scroller/Cargo.toml
+++ b/examples/src/std-scroller/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.13.1" , path = ".pax/pkg/pax-engine" }
-pax-std = { version = "0.13.1" , path = ".pax/pkg/pax-std" }
-pax-compiler = { version = "0.13.1", optional = true, path = ".pax/pkg/pax-compiler" }
-pax-manifest = { version = "0.13.1", optional = true, path = ".pax/pkg/pax-manifest" }
+pax-engine = { version = "0.13.1"}
+pax-std = { version = "0.13.1"}
+pax-compiler = { version = "0.13.1", optional = true}
+pax-manifest = { version = "0.13.1", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/std-scroller/bin/run.rs
+++ b/examples/src/std-scroller/bin/run.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let pax_args = {
+        let mut extended_args = vec!["run"];
+        extended_args.extend(args.iter().map(|arg| arg.as_str()));
+        extended_args
+    };
+
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+
+    let status = Command::new("./pax")
+        .args(&pax_args)
+        .current_dir(current_dir)
+        .status()
+        .expect("Failed to execute pax-cli");
+
+    std::process::exit(status.code().unwrap_or(1));
+}

--- a/examples/src/std-scroller/pax
+++ b/examples/src/std-scroller/pax
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+### Helper script for pax libdev, allowing pax-cli-like ergonomics inside the pax-example directory
+###
+### For example, from @/pax root:
+### `cd pax-example && ./pax run --target=macos`
+### `cd pax-example && ./pax parse`
+### `cd pax-example && ./pax libdev build-chassis`
+
+set -e
+current_dir=$(pwd)
+pushd ../../../pax-cli
+cargo build
+PAX_WORKSPACE_ROOT=.. ../target/debug/pax-cli "$@" --path="$current_dir" --libdev
+popd

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,4 +1,4 @@
-<Scroller  bound_x=100% bound_y=750% damping=0.04>
+<Scroller  bound_x=100% bound_y=750%>
     <Group>
         <Group>
             <Rectangle height=50% fill=RED/>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,0 +1,7 @@
+<Scroller>
+    <Group>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle y=50% height=50% fill=BLUE/>
+        <Rectangle y=100% height=50% fill=GREEN/>
+    </Group>
+</Scroller>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,30 +1,28 @@
 <Scroller  bound_x=200% bound_y=750%>
+    <Button label="test" width=200px height=30px  @click=self.on_click/>
     <Group>
-        <Button label="test" width=200px height=30px  @click=self.on_click/>
-        <Group>
-            <Rectangle height=50% fill=RED/>
-            <Rectangle y=50% height=50% fill=BLUE/>
-            <Rectangle y=100% height=50% fill=GREEN/>
-        </Group>
-        <Group y=150%>
-            <Rectangle height=50% fill=RED/>
-            <Rectangle y=50% height=50% fill=BLUE/>
-            <Rectangle y=100% height=50% fill=GREEN/>
-        </Group>
-        <Group y=300%>
-            <Rectangle height=50% fill=RED/>
-            <Rectangle y=50% height=50% fill=BLUE/>
-            <Rectangle y=100% height=50% fill=GREEN/>
-        </Group>
-        <Group y=450%>
-            <Rectangle height=50% fill=RED/>
-            <Rectangle y=50% height=50% fill=BLUE/>
-            <Rectangle y=100% height=50% fill=GREEN/>
-        </Group>
-        <Group y=600%>
-            <Rectangle height=50% fill=RED/>
-            <Rectangle y=50% height=50% fill=BLUE/>
-            <Rectangle y=100% height=50% fill=GREEN/>
-        </Group>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle x=50% y=50% height=50% fill=BLUE/>
+        <Rectangle x=100% y=100% height=50% fill=GREEN/>
+    </Group>
+    <Group y=150%>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle x=50% y=50% height=50% fill=BLUE/>
+        <Rectangle x=100% y=100% height=50% fill=GREEN/>
+    </Group>
+    <Group y=300%>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle x=50% y=50% height=50% fill=BLUE/>
+        <Rectangle x=100% y=100% height=50% fill=GREEN/>
+    </Group>
+    <Group y=450%>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle x=50% y=50% height=50% fill=BLUE/>
+        <Rectangle x=100% y=100% height=50% fill=GREEN/>
+    </Group>
+    <Group y=600%>
+        <Rectangle height=50% fill=RED/>
+        <Rectangle x=50% y=50% height=50% fill=BLUE/>
+        <Rectangle x=100% y=100% height=50% fill=GREEN/>
     </Group>
 </Scroller>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,5 +1,6 @@
-<Scroller  bound_x=100% bound_y=750%>
+<Scroller  bound_x=200% bound_y=750%>
     <Group>
+        <Button label="test" width=200px height=30px  @click=self.on_click/>
         <Group>
             <Rectangle height=50% fill=RED/>
             <Rectangle y=50% height=50% fill=BLUE/>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,4 +1,4 @@
-<Scroller  bound_x=200% bound_y=750%>
+<Scroller  scroll_width=200% scroll_height=750%>
     <Button label="test" width=200px height=30px  @click=self.on_click/>
     <Group>
         <Rectangle height=50% fill=RED/>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,23 +1,29 @@
-<Scroller  bound_x=100% bound_y=600% damping=0.05>
+<Scroller  bound_x=100% bound_y=750% damping=0.04>
     <Group>
-        <Text x=50% y=150% anchor_x=50% anchor_y=50% height=30px width=50% text="Hello World"/>
         <Group>
             <Rectangle height=50% fill=RED/>
             <Rectangle y=50% height=50% fill=BLUE/>
             <Rectangle y=100% height=50% fill=GREEN/>
-            <Rectangle y=150% height=50% fill=YELLOW/>
         </Group>
-        <Group>
-            <Rectangle y=200% height=50% fill=BLACK/>
-            <Rectangle y=250% height=50% fill=WHITE/>
-            <Rectangle y=300% height=50% fill=BLACK/>
-            <Rectangle y=350% height=50% fill=BLUE/>
+        <Group y=150%>
+            <Rectangle height=50% fill=RED/>
+            <Rectangle y=50% height=50% fill=BLUE/>
+            <Rectangle y=100% height=50% fill=GREEN/>
         </Group>
-        <Group>
-            <Rectangle y=400% height=50% fill=GREEN/>
-            <Rectangle y=450% height=50% fill=YELLOW/>
-            <Rectangle y=500% height=50% fill=BLACK/>
-            <Rectangle y=550% height=50% fill=WHITE/>
+        <Group y=300%>
+            <Rectangle height=50% fill=RED/>
+            <Rectangle y=50% height=50% fill=BLUE/>
+            <Rectangle y=100% height=50% fill=GREEN/>
+        </Group>
+        <Group y=450%>
+            <Rectangle height=50% fill=RED/>
+            <Rectangle y=50% height=50% fill=BLUE/>
+            <Rectangle y=100% height=50% fill=GREEN/>
+        </Group>
+        <Group y=600%>
+            <Rectangle height=50% fill=RED/>
+            <Rectangle y=50% height=50% fill=BLUE/>
+            <Rectangle y=100% height=50% fill=GREEN/>
         </Group>
     </Group>
 </Scroller>

--- a/examples/src/std-scroller/src/lib.pax
+++ b/examples/src/std-scroller/src/lib.pax
@@ -1,7 +1,23 @@
-<Scroller>
+<Scroller  bound_x=100% bound_y=600% damping=0.05>
     <Group>
-        <Rectangle height=50% fill=RED/>
-        <Rectangle y=50% height=50% fill=BLUE/>
-        <Rectangle y=100% height=50% fill=GREEN/>
+        <Text x=50% y=150% anchor_x=50% anchor_y=50% height=30px width=50% text="Hello World"/>
+        <Group>
+            <Rectangle height=50% fill=RED/>
+            <Rectangle y=50% height=50% fill=BLUE/>
+            <Rectangle y=100% height=50% fill=GREEN/>
+            <Rectangle y=150% height=50% fill=YELLOW/>
+        </Group>
+        <Group>
+            <Rectangle y=200% height=50% fill=BLACK/>
+            <Rectangle y=250% height=50% fill=WHITE/>
+            <Rectangle y=300% height=50% fill=BLACK/>
+            <Rectangle y=350% height=50% fill=BLUE/>
+        </Group>
+        <Group>
+            <Rectangle y=400% height=50% fill=GREEN/>
+            <Rectangle y=450% height=50% fill=YELLOW/>
+            <Rectangle y=500% height=50% fill=BLACK/>
+            <Rectangle y=550% height=50% fill=WHITE/>
+        </Group>
     </Group>
 </Scroller>

--- a/examples/src/std-scroller/src/lib.rs
+++ b/examples/src/std-scroller/src/lib.rs
@@ -13,3 +13,9 @@ use pax_std::types::*;
 #[main]
 #[file("lib.pax")]
 pub struct Example {}
+
+impl Example {
+    pub fn on_click(&mut self, ctx: &NodeContext, event: Event<Click>) {
+        log::debug!("click registered!!");
+    }
+}

--- a/examples/src/std-scroller/src/lib.rs
+++ b/examples/src/std-scroller/src/lib.rs
@@ -1,0 +1,15 @@
+#![allow(unused_imports)]
+
+use pax_engine::api::*;
+use pax_engine::*;
+use pax_std::components::Scroller;
+use pax_std::components::Stacker;
+use pax_std::components::*;
+use pax_std::primitives::*;
+use pax_std::types::text::*;
+use pax_std::types::*;
+
+#[pax]
+#[main]
+#[file("lib.pax")]
+pub struct Example {}

--- a/examples/std-scroller.rs
+++ b/examples/std-scroller.rs
@@ -1,0 +1,8 @@
+mod scripts;
+use scripts::run_example;
+
+fn main() {
+    if let Err(error) = run_example() {
+        eprintln!("Error: {}", error);
+    }
+}

--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -21,7 +21,7 @@ use pax_runtime::{ExpressionTable, PaxEngine, Renderer};
 //Note that any types exposed by pax_message must ALSO be added to `PaxCartridge.h`
 //in order to be visible to Swift
 pub use pax_message::*;
-use pax_runtime::api::{Click, ModifierKey, MouseButton, MouseEventArgs, RenderContext};
+use pax_runtime::api::{Click, ModifierKey, MouseButton, MouseEventArgs, RenderContext, OS};
 
 /// Container data structure for PaxEngine, aggregated to support passing across C bridge
 #[repr(C)] //Exposed to Swift via PaxCartridge.h
@@ -48,6 +48,7 @@ pub extern "C" fn pax_init() -> *mut PaxEngineContainer {
         main_component_instance,
         expression_table,
         (1.0, 1.0),
+        pax_runtime::api::Platform::Native(OS::Mac),
     )));
 
     let container = ManuallyDrop::new(Box::new(PaxEngineContainer {

--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -21,7 +21,9 @@ use pax_runtime::{ExpressionTable, PaxEngine, Renderer};
 //Note that any types exposed by pax_message must ALSO be added to `PaxCartridge.h`
 //in order to be visible to Swift
 pub use pax_message::*;
-use pax_runtime::api::{Click, ModifierKey, MouseButton, MouseEventArgs, RenderContext, OS};
+use pax_runtime::api::{
+    Click, ModifierKey, MouseButton, MouseEventArgs, Platform, RenderContext, OS,
+};
 
 /// Container data structure for PaxEngine, aggregated to support passing across C bridge
 #[repr(C)] //Exposed to Swift via PaxCartridge.h
@@ -48,7 +50,8 @@ pub extern "C" fn pax_init() -> *mut PaxEngineContainer {
         main_component_instance,
         expression_table,
         (1.0, 1.0),
-        pax_runtime::api::Platform::Native(OS::Mac),
+        Platform::Native,
+        OS::Mac,
     )));
 
     let container = ManuallyDrop::new(Box::new(PaxEngineContainer {

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -29,7 +29,7 @@ js-sys = "0.3.63"
 
 [dependencies.web-sys]
 version = "0.3.10"
-features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlCanvasElement", "Event", "HtmlCollection"]
+features = ["Navigator", "console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlCanvasElement", "Event", "HtmlCollection"]
 
 [profile.release]
 lto = true

--- a/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
+++ b/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
@@ -1,33 +1,32 @@
 export class ScrollerUpdatePatch {
-    public id_chain?: number[];
-    public size_x?: number;
-    public size_y?: number;
-    public size_inner_pane_x? : number;
-    public size_inner_pane_y? : number;
+    public idChain?: number[];
+    public sizeX?: number;
+    public sizeY?: number;
+    public sizeInnerPaneX? : number;
+    public sizeInnerPaneY? : number;
     public transform? : number[];
-    public scroll_x? : boolean;
-    public scroll_y? : boolean;
+    public scrollX? : boolean;
+    public scrollY? : boolean;
 
     fromPatch(jsonMessage: any) {
-        this.id_chain = jsonMessage["id_chain"];
-        this.size_x = jsonMessage["size_x"];
-        this.size_y = jsonMessage["size_y"];
-        this.size_inner_pane_x = jsonMessage["size_inner_pane_x"];
-        this.size_inner_pane_y = jsonMessage["size_inner_pane_y"];
+        this.idChain = jsonMessage["id_chain"];
+        this.sizeX = jsonMessage["size_x"];
+        this.sizeY = jsonMessage["size_y"];
+        this.sizeInnerPaneX = jsonMessage["size_inner_pane_x"];
+        this.sizeInnerPaneY = jsonMessage["size_inner_pane_y"];
         this.transform = jsonMessage["transform"];
-        this.scroll_x = jsonMessage["scroll_x"];
-        this.scroll_y = jsonMessage["scroll_y"];
+        this.scrollX = jsonMessage["scroll_x"];
+        this.scrollY = jsonMessage["scroll_y"];
     }
 
     cleanUp(){
-        this.id_chain = [];
-        this.size_x = 0;
-        this.size_y = 0;
-        this.size_inner_pane_x = 0;
-        this.size_inner_pane_y = 0;
+        this.idChain = [];
+        this.sizeX = 0;
+        this.sizeY = 0;
+        this.sizeInnerPaneX = 0;
+        this.sizeInnerPaneY = 0;
         this.transform = [];
-        this.scroll_x = false;
-        this.scroll_y = false;
-        this.subtreeDepth = 0;
+        this.scrollX = false;
+        this.scrollY = false;
     }
 }

--- a/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
+++ b/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
@@ -1,35 +1,34 @@
 export class ScrollerUpdatePatch {
-    public idChain?: number[];
-    public sizeX?: number;
-    public sizeY?: number;
-    public sizeInnerPaneX? : number;
-    public sizeInnerPaneY? : number;
+    public id_chain?: number[];
+    public size_x?: number;
+    public size_y?: number;
+    public size_inner_pane_x? : number;
+    public size_inner_pane_y? : number;
     public transform? : number[];
-    public scrollX? : boolean;
-    public scrollY? : boolean;
+    public scroll_x? : boolean;
+    public scroll_y? : boolean;
     public subtreeDepth?: number;
 
     fromPatch(jsonMessage: any) {
-        this.idChain = jsonMessage["id_chain"];
-        this.sizeX = jsonMessage["size_x"];
-        this.sizeY = jsonMessage["size_y"];
-        this.sizeInnerPaneX = jsonMessage["size_inner_pane_x"];
-        this.sizeInnerPaneY = jsonMessage["size_inner_pane_y"];
+        this.id_chain = jsonMessage["id_chain"];
+        this.size_x = jsonMessage["size_x"];
+        this.size_y = jsonMessage["size_y"];
+        this.size_inner_pane_x = jsonMessage["size_inner_pane_x"];
+        this.size_inner_pane_y = jsonMessage["size_inner_pane_y"];
         this.transform = jsonMessage["transform"];
-        this.scrollX = jsonMessage["scroll_x"];
-        this.scrollY = jsonMessage["scroll_y"];
-        this.subtreeDepth = jsonMessage["subtree_depth"];
+        this.scroll_x = jsonMessage["scroll_x"];
+        this.scroll_y = jsonMessage["scroll_y"];
     }
 
     cleanUp(){
-        this.idChain = [];
-        this.sizeX = 0;
-        this.sizeY = 0;
-        this.sizeInnerPaneX = 0;
-        this.sizeInnerPaneY = 0;
+        this.id_chain = [];
+        this.size_x = 0;
+        this.size_y = 0;
+        this.size_inner_pane_x = 0;
+        this.size_inner_pane_y = 0;
         this.transform = [];
-        this.scrollX = false;
-        this.scrollY = false;
+        this.scroll_x = false;
+        this.scroll_y = false;
         this.subtreeDepth = 0;
     }
 }

--- a/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
+++ b/pax-chassis-web/interface/src/classes/messages/scroller-update-patch.ts
@@ -7,7 +7,6 @@ export class ScrollerUpdatePatch {
     public transform? : number[];
     public scroll_x? : boolean;
     public scroll_y? : boolean;
-    public subtreeDepth?: number;
 
     fromPatch(jsonMessage: any) {
         this.id_chain = jsonMessage["id_chain"];

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -629,40 +629,33 @@ export class NativeElementPool {
 
     scrollerUpdate(patch: ScrollerUpdatePatch){
         // @ts-ignore
-        let leaf = this.textNodes[patch.id_chain];
+        let leaf = this.textNodes[patch.idChain];
         console.assert(leaf !== undefined);
 
         let scroller_inner = leaf.firstChild;
         // Handle size_x and size_y
-        if (patch.size_x != null) {
-            leaf.style.width = patch.size_x + "px";
+        if (patch.sizeX != null) {
+            leaf.style.width = patch.sizeX + "px";
         }
-        if (patch.size_y != null) {
-            leaf.style.height = patch.size_y + "px";
+        if (patch.sizeY != null) {
+            leaf.style.height = patch.sizeY + "px";
         }
-        if (patch.scroll_x != null) {
-            leaf.scrollLeft = patch.scroll_x;
+        if (patch.scrollX != null) {
+            leaf.scrollLeft = patch.scrollX;
         }
-        if (patch.scroll_y != null) {
-            leaf.scrollTop = patch.scroll_y;
+        if (patch.scrollY != null) {
+            leaf.scrollTop = patch.scrollY;
         }
         // Handle transform
         if (patch.transform != null) {
             leaf.style.transform = packAffineCoeffsIntoMatrix3DString(patch.transform);
         }
 
-        if (patch.size_inner_pane_x != null) {
-            scroller_inner.style.width = patch.size_inner_pane_x + "px";
+        if (patch.sizeInnerPaneX != null) {
+            scroller_inner.style.width = patch.sizeInnerPaneX + "px";
         }
-        if (patch.size_inner_pane_y != null) {
-            scroller_inner.style.height = patch.size_inner_pane_y + "px";
-        }
-
-        if (patch.scroll_enabled_x != null) {
-           // TODO enable/disable 
-        }
-        if (patch.scroll_enabled_x != null) {
-           // TODO enable/disable 
+        if (patch.sizeInnerPaneY != null) {
+            scroller_inner.style.height = patch.sizeInnerPaneY + "px";
         }
     }
 

--- a/pax-chassis-web/interface/src/index.ts
+++ b/pax-chassis-web/interface/src/index.ts
@@ -127,6 +127,19 @@ export function processMessages(messages: any[], chassis: PaxChassisWeb, objectM
             let patch: OcclusionUpdatePatch = objectManager.getFromPool(OCCLUSION_UPDATE_PATCH);
             patch.fromPatch(msg);
             nativePool.occlusionUpdate(patch);
+        } else if(unwrapped_msg["ScrollerCreate"]) {
+            let msg = unwrapped_msg["ScrollerCreate"]
+            let patch: AnyCreatePatch = objectManager.getFromPool(ANY_CREATE_PATCH);
+            patch.fromPatch(msg);
+            nativePool.scrollerCreate(patch);
+        } else if (unwrapped_msg["ScrollerUpdate"]){
+            let msg = unwrapped_msg["ScrollerUpdate"]
+            let patch: ScrollerUpdatePatch = objectManager.getFromPool(SCROLLER_UPDATE_PATCH, objectManager);
+            patch.fromPatch(msg);
+            nativePool.scrollerUpdate(patch);
+        }else if (unwrapped_msg["ScrollerDelete"]) {
+            let msg = unwrapped_msg["ScrollerDelete"];
+            nativePool.scrollerDelete(msg)
         } else if(unwrapped_msg["ButtonCreate"]) {
             let msg = unwrapped_msg["ButtonCreate"]
             let patch: AnyCreatePatch = objectManager.getFromPool(ANY_CREATE_PATCH);

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -80,10 +80,8 @@ impl PaxChassisWeb {
             .expect("console_log::init_with_level initialized correctly");
 
         let window = window().unwrap();
-        let os_info = window
-            .navigator()
-            .user_agent()
-            .ok()
+        let user_agent_str = window.navigator().user_agent().ok();
+        let os_info = user_agent_str
             .and_then(|s| parse_user_agent_str(&s))
             .unwrap_or_default();
 
@@ -708,7 +706,7 @@ fn parse_user_agent_str(user_agent: &str) -> Option<OS> {
     // Mozilla/5.0 (Linux; Android 12; SM-X906C Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko)
     // Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36
     let platform_start = user_agent.find('(')?;
-    let platform_end = user_agent[platform_start..].find(')')?;
+    let platform_end = platform_start + user_agent[platform_start..].find(')')?;
     let platform_str = user_agent.get(platform_start + 1..platform_end - 1)?;
 
     // NOTE: the ordering here is important: Android/iOS can contain Linux/MacOS strings

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -458,15 +458,15 @@ pub struct LinkStyleMessage {
 #[repr(C)]
 pub struct ScrollerPatch {
     pub id_chain: Vec<u32>,
+    pub transform: Option<Vec<f64>>,
     pub size_x: Option<f64>,
     pub size_y: Option<f64>,
     pub size_inner_pane_x: Option<f64>,
     pub size_inner_pane_y: Option<f64>,
-    pub transform: Option<Vec<f64>>,
     pub scroll_x: Option<f64>,
     pub scroll_y: Option<f64>,
-    pub scroll_enabled_x: Option<f64>,
-    pub scroll_enabled_y: Option<f64>,
+    pub scroll_enabled_x: Option<bool>,
+    pub scroll_enabled_y: Option<bool>,
     pub subtree_depth: u32,
 }
 

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -463,8 +463,10 @@ pub struct ScrollerPatch {
     pub size_inner_pane_x: Option<f64>,
     pub size_inner_pane_y: Option<f64>,
     pub transform: Option<Vec<f64>>,
-    pub scroll_x: Option<bool>,
-    pub scroll_y: Option<bool>,
+    pub scroll_x: Option<f64>,
+    pub scroll_y: Option<f64>,
+    pub scroll_enabled_x: Option<f64>,
+    pub scroll_enabled_y: Option<f64>,
     pub subtree_depth: u32,
 }
 

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -57,6 +57,25 @@ impl<T: std::fmt::Debug> std::fmt::Debug for TransitionQueueEntry<T> {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy)]
+pub enum OS {
+    Mac,
+    Linux,
+    Windows,
+    Android,
+    IPhone,
+    #[default]
+    Unknown,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub enum Platform {
+    Web,
+    Native,
+    #[default]
+    Unknown,
+}
+
 pub struct Window;
 
 impl Space for Window {}

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -21,6 +21,8 @@ pub struct NodeContext {
     pub platform: Platform,
     /// Current os (Android/Windows/Mac/Linux) this app is running on
     pub os: OS,
+    /// The number of slot children provided to this component template
+    pub slot_children: usize,
     /// Borrow of the RuntimeContext, used at least for exposing raycasting to userland
     #[allow(unused)]
     pub(crate) runtime_context: Rc<RefCell<RuntimeContext>>,

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -17,6 +17,10 @@ pub struct NodeContext {
     pub bounds_parent: Property<(f64, f64)>,
     /// The bounds of this element in px
     pub bounds_self: Property<(f64, f64)>,
+    /// Current platform (Web/Native) this app is running on
+    pub platform: Platform,
+    /// Current os (Android/Windows/Mac/Linux) this app is running on
+    pub os: OS,
     /// Borrow of the RuntimeContext, used at least for exposing raycasting to userland
     #[allow(unused)]
     pub(crate) runtime_context: Rc<RefCell<RuntimeContext>>,

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -496,11 +496,27 @@ impl ExpandedNode {
             globals.viewport.bounds.clone()
         };
 
+        let slot_children = if self.instance_node.borrow().base().flags().is_component {
+            self.expanded_and_flattened_slot_children
+                .borrow()
+                .as_ref()
+                .map(|c| c.len())
+        } else {
+            self.containing_component.upgrade().and_then(|v| {
+                v.expanded_and_flattened_slot_children
+                    .borrow()
+                    .as_ref()
+                    .map(|c| c.len())
+            })
+        }
+        .unwrap_or_default();
+
         NodeContext {
             frames_elapsed: globals.frames_elapsed.clone(),
             bounds_self,
             bounds_parent,
             runtime_context: context.clone(),
+            slot_children,
             platform: globals.platform.clone(),
             os: globals.os.clone(),
             #[cfg(feature = "designtime")]

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -123,27 +123,7 @@ macro_rules! dispatch_event_handler {
                     Rc::clone(&self.properties.borrow())
                 };
 
-                let comp_props = self.layout_properties.borrow();
-                let bounds_self = comp_props.bounds.clone();
-                let bounds_parent = self
-                    .parent_expanded_node
-                    .borrow()
-                    .upgrade()
-                    .map(|parent| {
-                        let comp_props = parent.layout_properties.borrow();
-                        let bounds_parent = comp_props.bounds.clone();
-                        bounds_parent
-                    })
-                    .unwrap_or(globals.viewport.bounds.clone());
-                let context = NodeContext {
-                    bounds_self,
-                    bounds_parent,
-                    frames_elapsed: globals.frames_elapsed.clone(),
-                    runtime_context: ctx.clone(),
-                    #[cfg(feature = "designtime")]
-                    designtime: globals.designtime.clone(),
-                };
-
+                let context = self.get_node_context(ctx);
                 let borrowed_registry = &(*registry).borrow();
                 if let Some(handlers) = borrowed_registry.handlers.get($handler_key) {
                     handlers.iter().for_each(|handler| {
@@ -521,6 +501,8 @@ impl ExpandedNode {
             bounds_self,
             bounds_parent,
             runtime_context: context.clone(),
+            platform: globals.platform.clone(),
+            os: globals.os.clone(),
             #[cfg(feature = "designtime")]
             designtime: globals.designtime.clone(),
         }

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use kurbo::Affine;
 use pax_manifest::UniqueTemplateNodeIdentifier;
 use pax_message::{NativeMessage, OcclusionPatch};
-use pax_runtime_api::math::Transform2;
+use pax_runtime_api::{math::Transform2, OS};
 
 use crate::api::{KeyDown, KeyPress, KeyUp, Layer, NodeContext, OcclusionLayerGen, RenderContext};
 use piet::InterpolationMode;
@@ -16,6 +16,7 @@ use piet::InterpolationMode;
 use crate::{
     ComponentInstance, ExpressionContext, InstanceNode, RuntimeContext, RuntimePropertiesStackFrame,
 };
+use pax_runtime_api::Platform;
 
 pub mod node_interface;
 
@@ -41,6 +42,8 @@ use self::expanded_node::LayoutProperties;
 pub struct Globals {
     pub frames_elapsed: Property<u64>,
     pub viewport: LayoutProperties,
+    pub platform: Platform,
+    pub os: OS,
     #[cfg(feature = "designtime")]
     pub designtime: Rc<RefCell<DesigntimeManager>>,
 }
@@ -228,6 +231,8 @@ impl PaxEngine {
         main_component_instance: Rc<ComponentInstance>,
         expression_table: ExpressionTable,
         viewport_size: (f64, f64),
+        platform: Platform,
+        os: OS,
     ) -> Self {
         use pax_runtime_api::properties;
 
@@ -239,6 +244,8 @@ impl PaxEngine {
                 transform: Property::new(Transform2::identity()),
                 bounds: Property::new(viewport_size),
             },
+            platform,
+            os,
         };
 
         let runtime_context = Rc::new(RefCell::new(RuntimeContext::new(expression_table, globals)));
@@ -258,6 +265,8 @@ impl PaxEngine {
         expression_table: ExpressionTable,
         viewport_size: (f64, f64),
         designtime: Rc<RefCell<DesigntimeManager>>,
+        platform: Platform,
+        os: OS,
     ) -> Self {
         use pax_runtime_api::math::Transform2;
         let frames_elapsed = Property::new(0);
@@ -268,6 +277,8 @@ impl PaxEngine {
                 transform: Transform2::default(),
                 bounds: viewport_size,
             },
+            platform,
+            os,
             designtime: designtime.clone(),
         };
 

--- a/pax-std/pax-std-primitives/src/frame.rs
+++ b/pax-std/pax-std-primitives/src/frame.rs
@@ -81,7 +81,7 @@ impl InstanceNode for FrameInstance {
 
     fn handle_unmount(
         &self,
-        _expanded_node: &Rc<ExpandedNode>,
+        expanded_node: &Rc<ExpandedNode>,
         _context: &Rc<RefCell<RuntimeContext>>,
     ) {
     }

--- a/pax-std/pax-std-primitives/src/lib.rs
+++ b/pax-std/pax-std-primitives/src/lib.rs
@@ -1,12 +1,12 @@
+pub mod button;
+pub mod checkbox;
 pub mod ellipse;
 pub mod frame;
 pub mod group;
 pub mod image;
 pub mod path;
 pub mod rectangle;
-// pub mod scroller;
-pub mod button;
-pub mod checkbox;
+pub mod scroller;
 pub mod text;
 pub mod textbox;
 

--- a/pax-std/pax-std-primitives/src/lib.rs
+++ b/pax-std/pax-std-primitives/src/lib.rs
@@ -6,7 +6,7 @@ pub mod group;
 pub mod image;
 pub mod path;
 pub mod rectangle;
-pub mod scroller;
+pub mod scrollbar;
 pub mod text;
 pub mod textbox;
 

--- a/pax-std/pax-std-primitives/src/scrollbar.rs
+++ b/pax-std/pax-std-primitives/src/scrollbar.rs
@@ -1,6 +1,6 @@
 use core::option::Option::Some;
 use pax_runtime::{BaseInstance, InstanceFlags, RuntimeContext};
-use pax_std::primitives::PrimitiveScroller;
+use pax_std::primitives::Scrollbar;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -17,7 +17,7 @@ use crate::patch_if_needed;
 /// `Scroller` translates its children to reflect the current scroll position.
 /// When both scrolling axes are disabled, `Scroller` acts exactly like a `Frame`, with a possibly-
 /// transformed `Group` surrounding its contents.
-pub struct ScrollerInstance {
+pub struct ScrollbarInstance {
     base: BaseInstance,
     // Properties that listen to Text property changes, and computes
     // a patch in the case that they have changed + sends it as a native
@@ -26,7 +26,7 @@ pub struct ScrollerInstance {
     native_message_props: RefCell<HashMap<u32, Property<()>>>,
 }
 
-impl InstanceNode for ScrollerInstance {
+impl InstanceNode for ScrollbarInstance {
     fn instantiate(args: InstantiationArgs) -> Rc<Self>
     where
         Self: Sized,
@@ -105,51 +105,49 @@ impl InstanceNode for ScrollerInstance {
                         id_chain: id_chain.clone(),
                         ..Default::default()
                     };
-                    expanded_node.with_properties_unwrapped(
-                        |properties: &mut PrimitiveScroller| {
-                            let computed_tab = &expanded_node.layout_properties;
-                            let (width, height) = computed_tab.bounds.get();
-                            let updates = [
-                                patch_if_needed(
-                                    &mut old_state.size_inner_pane_x,
-                                    &mut patch.size_inner_pane_x,
-                                    properties.size_inner_pane_x.get().get_pixels(width),
-                                ),
-                                patch_if_needed(
-                                    &mut old_state.size_inner_pane_y,
-                                    &mut patch.size_inner_pane_y,
-                                    properties.size_inner_pane_y.get().get_pixels(height),
-                                ),
-                                patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
-                                patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
-                                patch_if_needed(
-                                    &mut old_state.scroll_x,
-                                    &mut patch.scroll_x,
-                                    properties.scroll_x.get(),
-                                ),
-                                patch_if_needed(
-                                    &mut old_state.scroll_y,
-                                    &mut patch.scroll_y,
-                                    properties.scroll_y.get(),
-                                ),
-                                patch_if_needed(
-                                    &mut old_state.scroll_x,
-                                    &mut patch.scroll_x,
-                                    properties.scroll_x.get(),
-                                ),
-                                patch_if_needed(
-                                    &mut old_state.transform,
-                                    &mut patch.transform,
-                                    computed_tab.transform.get().coeffs().to_vec(),
-                                ),
-                            ];
-                            if updates.into_iter().any(|v| v == true) {
-                                context.borrow_mut().enqueue_native_message(
-                                    pax_message::NativeMessage::ScrollerUpdate(patch),
-                                );
-                            }
-                        },
-                    );
+                    expanded_node.with_properties_unwrapped(|properties: &mut Scrollbar| {
+                        let computed_tab = &expanded_node.layout_properties;
+                        let (width, height) = computed_tab.bounds.get();
+                        let updates = [
+                            patch_if_needed(
+                                &mut old_state.size_inner_pane_x,
+                                &mut patch.size_inner_pane_x,
+                                properties.size_inner_pane_x.get().get_pixels(width),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.size_inner_pane_y,
+                                &mut patch.size_inner_pane_y,
+                                properties.size_inner_pane_y.get().get_pixels(height),
+                            ),
+                            patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
+                            patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
+                            patch_if_needed(
+                                &mut old_state.scroll_x,
+                                &mut patch.scroll_x,
+                                properties.scroll_x.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.scroll_y,
+                                &mut patch.scroll_y,
+                                properties.scroll_y.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.scroll_x,
+                                &mut patch.scroll_x,
+                                properties.scroll_x.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.transform,
+                                &mut patch.transform,
+                                computed_tab.transform.get().coeffs().to_vec(),
+                            ),
+                        ];
+                        if updates.into_iter().any(|v| v == true) {
+                            context.borrow_mut().enqueue_native_message(
+                                pax_message::NativeMessage::ScrollerUpdate(patch),
+                            );
+                        }
+                    });
                     ()
                 },
                 &deps,

--- a/pax-std/pax-std-primitives/src/scroller.rs
+++ b/pax-std/pax-std-primitives/src/scroller.rs
@@ -138,16 +138,6 @@ impl InstanceNode for ScrollerInstance {
                                     properties.scroll_x.get(),
                                 ),
                                 patch_if_needed(
-                                    &mut old_state.scroll_enabled_x,
-                                    &mut patch.scroll_enabled_x,
-                                    properties.scroll_enabled_x.get(),
-                                ),
-                                patch_if_needed(
-                                    &mut old_state.scroll_enabled_x,
-                                    &mut patch.scroll_enabled_x,
-                                    properties.scroll_enabled_x.get(),
-                                ),
-                                patch_if_needed(
                                     &mut old_state.transform,
                                     &mut patch.transform,
                                     computed_tab.transform.get().coeffs().to_vec(),

--- a/pax-std/pax-std-primitives/src/scroller.rs
+++ b/pax-std/pax-std-primitives/src/scroller.rs
@@ -1,6 +1,6 @@
 use core::option::Option::Some;
 use pax_runtime::{BaseInstance, InstanceFlags, RuntimeContext};
-use pax_std::primitives::Scroller;
+use pax_std::primitives::PrimitiveScroller;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -66,7 +66,7 @@ impl InstanceNode for ScrollerInstance {
         let id_chain = expanded_node.id_chain.clone();
         context
             .borrow_mut()
-            .enqueue_native_message(pax_message::NativeMessage::TextboxCreate(AnyCreatePatch {
+            .enqueue_native_message(pax_message::NativeMessage::ScrollerCreate(AnyCreatePatch {
                 id_chain: id_chain.clone(),
                 clipping_ids: vec![],
                 scroller_ids: vec![],
@@ -105,54 +105,61 @@ impl InstanceNode for ScrollerInstance {
                         id_chain: id_chain.clone(),
                         ..Default::default()
                     };
-                    expanded_node.with_properties_unwrapped(|properties: &mut Scroller| {
-                        let computed_tab = &expanded_node.layout_properties;
-                        let (width, height) = computed_tab.bounds.get();
-                        let updates = [
-                            patch_if_needed(
-                                &mut old_state.size_inner_pane_x,
-                                &mut patch.size_inner_pane_x,
-                                properties.size_inner_pane_x.get().get_pixels(width),
-                            ),
-                            patch_if_needed(
-                                &mut old_state.size_inner_pane_y,
-                                &mut patch.size_inner_pane_y,
-                                properties.size_inner_pane_y.get().get_pixels(height),
-                            ),
-                            patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
-                            patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
-                            patch_if_needed(
-                                &mut old_state.scroll_x,
-                                &mut patch.scroll_x,
-                                properties.scroll_x.get(),
-                            ),
-                            patch_if_needed(
-                                &mut old_state.scroll_y,
-                                &mut patch.scroll_y,
-                                properties.scroll_y.get(),
-                            ),
-                            patch_if_needed(
-                                &mut old_state.scroll_x,
-                                &mut patch.scroll_x,
-                                properties.scroll_x.get(),
-                            ),
-                            patch_if_needed(
-                                &mut old_state.scroll_enabled_x,
-                                &mut patch.scroll_enabled_x,
-                                properties.scroll_y.get(),
-                            ),
-                            patch_if_needed(
-                                &mut old_state.transform,
-                                &mut patch.transform,
-                                computed_tab.transform.get().coeffs().to_vec(),
-                            ),
-                        ];
-                        if updates.into_iter().any(|v| v == true) {
-                            context.borrow_mut().enqueue_native_message(
-                                pax_message::NativeMessage::ScrollerUpdate(patch),
-                            );
-                        }
-                    });
+                    expanded_node.with_properties_unwrapped(
+                        |properties: &mut PrimitiveScroller| {
+                            let computed_tab = &expanded_node.layout_properties;
+                            let (width, height) = computed_tab.bounds.get();
+                            let updates = [
+                                patch_if_needed(
+                                    &mut old_state.size_inner_pane_x,
+                                    &mut patch.size_inner_pane_x,
+                                    properties.size_inner_pane_x.get().get_pixels(width),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.size_inner_pane_y,
+                                    &mut patch.size_inner_pane_y,
+                                    properties.size_inner_pane_y.get().get_pixels(height),
+                                ),
+                                patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
+                                patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
+                                patch_if_needed(
+                                    &mut old_state.scroll_x,
+                                    &mut patch.scroll_x,
+                                    properties.scroll_x.get(),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.scroll_y,
+                                    &mut patch.scroll_y,
+                                    properties.scroll_y.get(),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.scroll_x,
+                                    &mut patch.scroll_x,
+                                    properties.scroll_x.get(),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.scroll_enabled_x,
+                                    &mut patch.scroll_enabled_x,
+                                    properties.scroll_enabled_x.get(),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.scroll_enabled_x,
+                                    &mut patch.scroll_enabled_x,
+                                    properties.scroll_enabled_x.get(),
+                                ),
+                                patch_if_needed(
+                                    &mut old_state.transform,
+                                    &mut patch.transform,
+                                    computed_tab.transform.get().coeffs().to_vec(),
+                                ),
+                            ];
+                            if updates.into_iter().any(|v| v == true) {
+                                context.borrow_mut().enqueue_native_message(
+                                    pax_message::NativeMessage::ScrollerUpdate(patch),
+                                );
+                            }
+                        },
+                    );
                     ()
                 },
                 &deps,
@@ -169,7 +176,7 @@ impl InstanceNode for ScrollerInstance {
         let id = id_chain[0];
         context
             .borrow_mut()
-            .enqueue_native_message(pax_message::NativeMessage::TextboxDelete(id_chain));
+            .enqueue_native_message(pax_message::NativeMessage::ScrollerDelete(id_chain));
         // Reset so that native_message sending updates while unmounted
         self.native_message_props.borrow_mut().remove(&id);
     }

--- a/pax-std/pax-std-primitives/src/scroller.rs
+++ b/pax-std/pax-std-primitives/src/scroller.rs
@@ -1,20 +1,15 @@
-use core::option::Option;
 use core::option::Option::Some;
+use pax_runtime::{BaseInstance, InstanceFlags, RuntimeContext};
+use pax_std::primitives::Scroller;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use kurbo::BezPath;
-use piet::RenderContext;
-
 use pax_message::{AnyCreatePatch, ScrollerPatch};
-use pax_runtime::api::{ArgsScroll, CommonProperties, EasingCurve, Layer, Property, Size};
-use pax_runtime::{
-    recurse_expand_nodes, ExpandedNode, HandlerRegistry, InstanceNode, InstanceNodePtr,
-    InstanceNodePtrList, InstantiationArgs, PropertiesComputable, PropertiesTreeContext,
-    RenderTreeContext,
-};
-use pax_std::primitives::Scroller;
+use pax_runtime::api::{Layer, Property};
+use pax_runtime::{ExpandedNode, InstanceNode, InstantiationArgs};
+
+use crate::patch_if_needed;
 
 /// A combination of a clipping area (nearly identical to a `Frame`,) and an
 /// inner panel that can be scrolled on zero or more axes.  `Scroller` coordinates with each chassis to
@@ -22,358 +17,172 @@ use pax_std::primitives::Scroller;
 /// `Scroller` translates its children to reflect the current scroll position.
 /// When both scrolling axes are disabled, `Scroller` acts exactly like a `Frame`, with a possibly-
 /// transformed `Group` surrounding its contents.
-pub struct ScrollerInstance<R: 'static + RenderContext> {
+pub struct ScrollerInstance {
     base: BaseInstance,
-    pub scroll_x: f64,
-    pub scroll_y: f64,
-    pub scroll_x_offset: Property<f64>,
-    pub scroll_y_offset: Property<f64>,
-    last_patches: HashMap<Vec<u32>, ScrollerPatch>,
+    // Properties that listen to Text property changes, and computes
+    // a patch in the case that they have changed + sends it as a native
+    // message to the chassi. Since InstanceNode -> ExpandedNode has a one
+    // to many relationship, needs to be a hashmap
+    native_message_props: RefCell<HashMap<u32, Property<()>>>,
 }
 
-impl<R: 'static + RenderContext> InstanceNode<R> for ScrollerInstance<R> {
-    fn get_layer_type(&mut self) -> Layer {
-        Layer::Scroller
-    }
-
-    fn new(args: InstantiationArgs<R>) -> Rc<RefCell<Self>>
+impl InstanceNode for ScrollerInstance {
+    fn instantiate(args: InstantiationArgs) -> Rc<Self>
     where
         Self: Sized,
     {
-        Rc::new(RefCell::new(Self {
-            last_patches: HashMap::new(),
-            scroll_x: 0.0,
-            scroll_y: 0.0,
-            scroll_x_offset: Property::new(0.0),
-            scroll_y_offset: Property::new(0.0),
-            base: BaseInstance::new(args),
-        }))
+        Rc::new(Self {
+            base: BaseInstance::new(
+                args,
+                InstanceFlags {
+                    invisible_to_slot: false,
+                    invisible_to_raycasting: false,
+                    layer: Layer::Native,
+                    is_component: false,
+                },
+            ),
+            native_message_props: Default::default(),
+        })
     }
-
-    fn handle_scroll(&mut self, args_scroll: ArgsScroll) {
-        self.scroll_x -= args_scroll.delta_x;
-        self.scroll_y -= args_scroll.delta_y;
-        (*self.scroll_x_offset)
-            .borrow_mut()
-            .ease_to(self.scroll_x, 2, EasingCurve::Linear);
-        (*self.scroll_y_offset)
-            .borrow_mut()
-            .ease_to(self.scroll_y, 2, EasingCurve::Linear);
-    }
-
-    fn get_scroll_offset(&mut self) -> (f64, f64) {
-        (
-            (*self.scroll_x_offset).borrow().get().clone(),
-            (*self.scroll_y_offset).borrow().get().clone(),
-        )
-    }
-
-    fn get_handler_registry(&self) -> Option<Rc<RefCell<HandlerRegistry<R>>>> {
-        match &self.handler_registry {
-            Some(registry) => Some(Rc::clone(&registry)),
-            _ => None,
-        }
-    }
-
-    fn handle_native_patches(
-        &mut self,
-        ptc: &mut PropertiesTreeContext<R>,
-        computed_size: (f64, f64),
-        transform_coeffs: Vec<f64>,
-        _z_index: u32,
-        subtree_depth: u32,
+    fn update(
+        self: Rc<Self>,
+        expanded_node: &Rc<ExpandedNode>,
+        _context: &Rc<RefCell<RuntimeContext>>,
     ) {
-        // let mut new_message: ScrollerPatch = Default::default();
-        // new_message.id_chain = ptc.get_id_chain();
-        // if !self.last_patches.contains_key(&new_message.id_chain) {
-        //     let mut patch = ScrollerPatch::default();
-        //     patch.id_chain = new_message.id_chain.clone();
-        //     self.last_patches
-        //         .insert(new_message.id_chain.clone(), patch);
-        // }
-        // let last_patch = self.last_patches.get_mut(&new_message.id_chain).unwrap();
-        // let mut has_any_updates = false;
-        //
-        // let wrapped = ptc.current_expanded_node.as_ref().unwrap().clone().borrow().get_properties().clone();
-        // with_properties_unsafe!(&wrapped, PropertiesCoproduct, Scroller, |properties: &mut Scroller| {
-        //     let val = subtree_depth;
-        //     let is_new_value = last_patch.subtree_depth != val;
-        //     if is_new_value {
-        //         new_message.subtree_depth = val;
-        //         last_patch.subtree_depth = val;
-        //         has_any_updates = true;
-        //     }
-        //
-        // let val = computed_size.0;
-        // let is_new_value = match &last_patch.size_x {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.size_x = Some(val);
-        //     last_patch.size_x = Some(val);
-        //     has_any_updates = true;
-        // }
-        //
-        // let val = computed_size.1;
-        // let is_new_value = match &last_patch.size_y {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.size_y = Some(val);
-        //     last_patch.size_y = Some(val);
-        //     has_any_updates = true;
-        // }
-        //
-        // let val = Size::get_pixels(properties.size_inner_pane_x.get(), computed_size.0);
-        // let is_new_value = match &last_patch.size_inner_pane_x {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.size_inner_pane_x = Some(val);
-        //     last_patch.size_inner_pane_x = Some(val);
-        //     has_any_updates = true;
-        // }
-        //
-        // let val = Size::get_pixels(properties.size_inner_pane_y.get(), computed_size.1);
-        // let is_new_value = match &last_patch.size_inner_pane_y {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.size_inner_pane_y = Some(val);
-        //     last_patch.size_inner_pane_y = Some(val);
-        //     has_any_updates = true;
-        // }
-        //
-        // let val = properties.scroll_enabled_x.get();
-        // let is_new_value = match &last_patch.scroll_x {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.scroll_x = Some(*val);
-        //     last_patch.scroll_x = Some(*val);
-        //     has_any_updates = true;
-        // }
-        //
-        // let val = properties.scroll_enabled_y.get();
-        // let is_new_value = match &last_patch.scroll_y {
-        //     Some(cached_value) => !val.eq(cached_value),
-        //     None => true,
-        // };
-        // if is_new_value {
-        //     new_message.scroll_y = Some(*val);
-        //     last_patch.scroll_y = Some(*val);
-        //     has_any_updates = true;
-        // }
-        //
-        //     let latest_transform = transform_coeffs;
-        //     let is_new_transform = match &last_patch.transform {
-        //         Some(cached_transform) => latest_transform
-        //             .iter()
-        //             .enumerate()
-        //             .any(|(i, elem)| *elem != cached_transform[i]),
-        //         None => true,
-        //     };
-        //     if is_new_transform {
-        //         new_message.transform = Some(latest_transform.clone());
-        //         last_patch.transform = Some(latest_transform.clone());
-        //         has_any_updates = true;
-        //     }
-        //
-        //     if has_any_updates {
-        //         ptc.enqueue_native_message(pax_message::NativeMessage::ScrollerUpdate(new_message));
-        //     }
-        // });
-        todo!()
+        //trigger computation of property that computes + sends native message update
+        self.native_message_props
+            .borrow()
+            .get(&expanded_node.id_chain[0])
+            .unwrap()
+            .get();
     }
 
-    fn get_instance_children(&self) -> InstanceNodePtrList<R> {
-        Rc::clone(&self.children)
-    }
-
-    fn get_clipping_size(&self, expanded_node: &ExpandedNode<R>) -> Option<(Size, Size)> {
-        let comm_props = expanded_node.get_common_properties();
-
-        // `ret` temp appeases borrow checker
-        let ret = Some((
-            comm_props.borrow().width.get().clone(),
-            comm_props.borrow().height.get().clone(),
-        ));
-        ret
-    }
-
-    /// Scroller's `size` is the size of its inner pane
-    fn get_size(&self, expanded_node: &ExpandedNode<R>) -> (Size, Size) {
-        let properties_wrapped = expanded_node.get_properties();
-        // with_properties_unsafe!(properties_wrapped, PropertiesCoproduct, Scroller, |properties : &mut Scroller|{
-        //     (
-        //         properties
-        //             .size_inner_pane_x
-        //             .get()
-        //             .clone(),
-        //         properties
-        //             .size_inner_pane_y
-        //             .get()
-        //             .clone(),
-        //     )
-        // })
-        todo!()
-    }
-
-    fn expand_node_and_compute_properties(
-        &mut self,
-        ptc: &mut PropertiesTreeContext<R>,
-    ) -> Rc<RefCell<ExpandedNode<R>>> {
-        let id_chain = ptc.get_id_chain();
-
-        // if true {
-        todo!("manage vtable evaluation for own properties");
-        // }
-
-        ptc.push_clipping_stack_id(id_chain.clone());
-        ptc.push_scroller_stack_id(id_chain.clone());
-
-        for child in self.get_instance_children().borrow().iter() {
-            let new_ptc = ptc.clone();
-            // let new_instance_node = Rc::clone(child);
-            // let new_expanded_node = new_instance_node.borrow().com
-            //
-            // recurse_expand_nodes();
-            todo!("manage children")
-        }
-
-        ptc.pop_clipping_stack_id();
-        ptc.pop_scroller_stack_id();
-        // self.common_properties.compute_properties(ptc);
-        //
-        // let mut scroll_x_offset_borrowed = (*self.scroll_x_offset).borrow_mut();
-        // if let Some(new_value) =
-        //     ptc.compute_eased_value(scroll_x_offset_borrowed._get_transition_manager())
-        // {
-        //     scroll_x_offset_borrowed.set(new_value);
-        // }
-        //
-        // let mut scroll_y_offset_borrowed = (*self.scroll_y_offset).borrow_mut();
-        // if let Some(new_value) =
-        //     ptc.compute_eased_value(scroll_y_offset_borrowed._get_transition_manager())
-        // {
-        //     scroll_y_offset_borrowed.set(new_value);
-        // }
-        //
-        // let properties = &mut *self.properties.as_ref().borrow_mut();
-        //
-        // if let Some(new_size) =
-        //     ptc.compute_vtable_value(properties.size_inner_pane_x._get_vtable_id())
-        // {
-        //     let new_value = if let TypesCoproduct::Size(v) = new_size {
-        //         v
-        //     } else {
-        //         unreachable!()
-        //     };
-        //     properties.size_inner_pane_x.set(new_value);
-        // }
-        //
-        // if let Some(new_size) =
-        //     ptc.compute_vtable_value(properties.size_inner_pane_y._get_vtable_id())
-        // {
-        //     let new_value = if let TypesCoproduct::Size(v) = new_size {
-        //         v
-        //     } else {
-        //         unreachable!()
-        //     };
-        //     properties.size_inner_pane_y.set(new_value);
-        // }
-        //
-        // if let Some(scroll_enabled_x) =
-        //     ptc.compute_vtable_value(properties.scroll_enabled_x._get_vtable_id())
-        // {
-        //     let new_value = if let TypesCoproduct::bool(v) = scroll_enabled_x {
-        //         v
-        //     } else {
-        //         unreachable!()
-        //     };
-        //     properties.scroll_enabled_x.set(new_value);
-        // }
-        //
-        // if let Some(scroll_enabled_y) =
-        //     ptc.compute_vtable_value(properties.scroll_enabled_y._get_vtable_id())
-        // {
-        //     let new_value = if let TypesCoproduct::bool(v) = scroll_enabled_y {
-        //         v
-        //     } else {
-        //         unreachable!()
-        //     };
-        //     properties.scroll_enabled_y.set(new_value);
-        // }
-        //
-        // self.common_properties.compute_properties(ptc);
-    }
-
-    fn manages_own_subtree_for_expansion(&self) -> bool {
-        true
-    }
-
-    fn handle_pre_render(&mut self, rtc: &mut RenderTreeContext<R>, rcs: &mut HashMap<String, R>) {
-        let expanded_node = rtc.current_expanded_node.borrow();
-        let tab = &expanded_node.tab;
-
-        let width: f64 = tab.bounds.0;
-        let height: f64 = tab.bounds.1;
-
-        let mut bez_path = BezPath::new();
-        bez_path.move_to((0.0, 0.0));
-        bez_path.line_to((width, 0.0));
-        bez_path.line_to((width, height));
-        bez_path.line_to((0.0, height));
-        bez_path.line_to((0.0, 0.0));
-        bez_path.close_path();
-
-        let transformed_bez_path = tab.transform * bez_path;
-        for (_key, rc) in rcs.iter_mut() {
-            rc.save().unwrap(); //our "save point" before clipping — restored to in the post_render
-            rc.clip(transformed_bez_path.clone());
-        }
-        let id_chain = rtc.current_expanded_node.borrow().id_chain.clone();
-    }
-    fn handle_post_render(
-        &mut self,
-        rtc: &mut RenderTreeContext<R>,
-        _rcs: &mut HashMap<String, R>,
+    fn handle_mount(
+        self: Rc<Self>,
+        expanded_node: &Rc<ExpandedNode>,
+        context: &Rc<RefCell<RuntimeContext>>,
     ) {
-        for (_key, rc) in _rcs.iter_mut() {
-            //pop the clipping context from the stack
-            rc.restore().unwrap();
-        }
-    }
+        // Send creation message
+        let id_chain = expanded_node.id_chain.clone();
+        context
+            .borrow_mut()
+            .enqueue_native_message(pax_message::NativeMessage::TextboxCreate(AnyCreatePatch {
+                id_chain: id_chain.clone(),
+                clipping_ids: vec![],
+                scroller_ids: vec![],
+                z_index: 0,
+            }));
 
-    fn handle_mount(&mut self, ptc: &mut PropertiesTreeContext<R>) {
-        let id_chain = ptc.get_id_chain();
-        let z_index = ptc.current_expanded_node.as_ref().unwrap().borrow().z_index;
-
-        //though macOS and iOS don't need this ancestry chain for clipping, Web does
-        let clipping_ids = ptc.get_current_clipping_ids();
-
-        let scroller_ids = ptc.get_current_scroller_ids();
-
-        ptc.enqueue_native_message(pax_message::NativeMessage::ScrollerCreate(AnyCreatePatch {
+        // send update message when relevant properties change
+        let weak_self_ref = Rc::downgrade(&expanded_node);
+        let context = Rc::clone(context);
+        let last_patch = Rc::new(RefCell::new(ScrollerPatch {
             id_chain: id_chain.clone(),
-            clipping_ids,
-            scroller_ids,
-            z_index,
+            ..Default::default()
         }));
+
+        let deps: Vec<_> = expanded_node
+            .properties_scope
+            .borrow()
+            .values()
+            .cloned()
+            .chain([
+                expanded_node.layout_properties.transform.untyped(),
+                expanded_node.layout_properties.bounds.untyped(),
+            ])
+            .collect();
+        self.native_message_props.borrow_mut().insert(
+            id_chain[0],
+            Property::computed(
+                move || {
+                    let Some(expanded_node) = weak_self_ref.upgrade() else {
+                        unreachable!()
+                    };
+                    let id_chain = expanded_node.id_chain.clone();
+                    let mut old_state = last_patch.borrow_mut();
+
+                    let mut patch = ScrollerPatch {
+                        id_chain: id_chain.clone(),
+                        ..Default::default()
+                    };
+                    expanded_node.with_properties_unwrapped(|properties: &mut Scroller| {
+                        let computed_tab = &expanded_node.layout_properties;
+                        let (width, height) = computed_tab.bounds.get();
+                        let updates = [
+                            patch_if_needed(
+                                &mut old_state.size_inner_pane_x,
+                                &mut patch.size_inner_pane_x,
+                                properties.size_inner_pane_x.get().get_pixels(width),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.size_inner_pane_y,
+                                &mut patch.size_inner_pane_y,
+                                properties.size_inner_pane_y.get().get_pixels(height),
+                            ),
+                            patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
+                            patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
+                            patch_if_needed(
+                                &mut old_state.scroll_x,
+                                &mut patch.scroll_x,
+                                properties.scroll_x.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.scroll_y,
+                                &mut patch.scroll_y,
+                                properties.scroll_y.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.scroll_x,
+                                &mut patch.scroll_x,
+                                properties.scroll_x.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.scroll_enabled_x,
+                                &mut patch.scroll_enabled_x,
+                                properties.scroll_y.get(),
+                            ),
+                            patch_if_needed(
+                                &mut old_state.transform,
+                                &mut patch.transform,
+                                computed_tab.transform.get().coeffs().to_vec(),
+                            ),
+                        ];
+                        if updates.into_iter().any(|v| v == true) {
+                            context.borrow_mut().enqueue_native_message(
+                                pax_message::NativeMessage::ScrollerUpdate(patch),
+                            );
+                        }
+                    });
+                    ()
+                },
+                &deps,
+            ),
+        );
     }
 
-    fn handle_unmount(&mut self, ptc: &mut PropertiesTreeContext<R>) {
-        let id_chain = ptc.get_id_chain();
-        self.last_patches.remove(&id_chain);
-        ptc.enqueue_native_message(pax_message::NativeMessage::ScrollerDelete(id_chain));
+    fn handle_unmount(
+        &self,
+        expanded_node: &Rc<ExpandedNode>,
+        context: &Rc<RefCell<RuntimeContext>>,
+    ) {
+        let id_chain = expanded_node.id_chain.clone();
+        let id = id_chain[0];
+        context
+            .borrow_mut()
+            .enqueue_native_message(pax_message::NativeMessage::TextboxDelete(id_chain));
+        // Reset so that native_message sending updates while unmounted
+        self.native_message_props.borrow_mut().remove(&id);
     }
-
     fn base(&self) -> &BaseInstance {
         &self.base
+    }
+
+    #[cfg(debug_assertions)]
+    fn resolve_debug(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _expanded_node: Option<&ExpandedNode>,
+    ) -> std::fmt::Result {
+        f.debug_struct("Scrollbar").finish_non_exhaustive()
     }
 }

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -36,6 +36,8 @@ pub mod primitives {
         pub size_inner_pane_y: Property<Size>,
         pub scroll_enabled_x: Property<bool>,
         pub scroll_enabled_y: Property<bool>,
+        pub scroll_x: Property<f64>,
+        pub scroll_y: Property<f64>,
     }
 
     #[pax]

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -31,7 +31,7 @@ pub mod primitives {
 
     #[pax]
     #[primitive("pax_std_primitives::scroller::ScrollerInstance")]
-    pub struct Scroller {
+    pub struct PrimitiveScroller {
         pub size_inner_pane_x: Property<Size>,
         pub size_inner_pane_y: Property<Size>,
         pub scroll_enabled_x: Property<bool>,

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -34,8 +34,6 @@ pub mod primitives {
     pub struct PrimitiveScroller {
         pub size_inner_pane_x: Property<Size>,
         pub size_inner_pane_y: Property<Size>,
-        pub scroll_enabled_x: Property<bool>,
-        pub scroll_enabled_y: Property<bool>,
         pub scroll_x: Property<f64>,
         pub scroll_y: Property<f64>,
     }

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -1,9 +1,12 @@
 pub mod types;
 
 #[allow(unused_imports)]
+pub mod scroller;
+#[allow(unused_imports)]
 pub mod stacker;
 
 pub mod components {
+    pub use super::scroller::*;
     pub use super::stacker::*;
 }
 

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -30,8 +30,8 @@ pub mod primitives {
     pub struct Group {}
 
     #[pax]
-    #[primitive("pax_std_primitives::scroller::ScrollerInstance")]
-    pub struct PrimitiveScroller {
+    #[primitive("pax_std_primitives::scroller::ScrollbarInstance")]
+    pub struct Scrollbar {
         pub size_inner_pane_x: Property<Size>,
         pub size_inner_pane_y: Property<Size>,
         pub scroll_x: Property<f64>,

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -7,6 +7,7 @@ use pax_engine::api::Numeric;
 use pax_engine::api::{Event, Wheel};
 use pax_engine::api::{Property, Size, Transform2D};
 use pax_engine::*;
+use pax_manifest::Number;
 use pax_runtime::api::{NodeContext, StringBox, TouchEnd, TouchMove, TouchStart};
 /// Stacker lays out a series of nodes either
 /// vertically or horizontally (i.e. a single row or column) with a specified gutter in between
@@ -32,11 +33,15 @@ use pax_runtime::api::{NodeContext, StringBox, TouchEnd, TouchMove, TouchStart};
 
 )]
 pub struct Scroller {
-    pub scroll_pos_x: Property<f64>,
-    pub scroll_pos_y: Property<f64>,
+    pub scroll_pos_x: Property<Numeric>,
+    pub scroll_pos_y: Property<Numeric>,
+    pub bound_x: Property<Size>,
+    pub bound_y: Property<Size>,
+    pub damping: Property<Numeric>,
+
+    // private fields
     pub momentum_x: Property<f64>,
     pub momentum_y: Property<f64>,
-    pub damping: Property<f64>,
     pub cached_damping: Property<f64>,
 }
 
@@ -52,76 +57,79 @@ thread_local! {
 // - how to not go to next page in Y direction? (args.prevent_default()?)
 
 impl Scroller {
-    pub fn on_mount(&mut self, _ctx: &NodeContext) {
-        self.damping.set(0.90);
-    }
+    pub fn on_mount(&mut self, _ctx: &NodeContext) {}
 
     pub fn update(&mut self, ctx: &NodeContext) {
         let mom_x = self.momentum_x.get();
         let mom_y = self.momentum_y.get();
         if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
-            let (bounds_x, bounds_y) = ctx.bounds_self.get();
-            let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
-            let old_x = self.scroll_pos_x.get();
-            let old_y = self.scroll_pos_y.get();
-            let target_x = old_x + mom_x;
-            let target_y = old_y + mom_y;
-            let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
-            let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
-            self.scroll_pos_x.set(clamped_target_x);
-            self.scroll_pos_y.set(clamped_target_y);
+            self.add_position(ctx, mom_x, mom_y);
         }
-        self.momentum_x.set(mom_x * self.damping.get());
-        self.momentum_y.set(mom_y * self.damping.get());
+        let mut new_mom_x = mom_x * (1.0 - self.damping.get().to_float());
+        let mut new_mom_y = mom_y * (1.0 - self.damping.get().to_float());
+        if new_mom_x.abs() < 0.1 {
+            new_mom_x = 0.0;
+        }
+        if new_mom_y.abs() < 0.1 {
+            new_mom_y = 0.0;
+        }
+        self.momentum_x.set(new_mom_x);
+        self.momentum_y.set(new_mom_y);
+    }
+
+    pub fn add_position(&self, ctx: &NodeContext, dx: f64, dy: f64) {
+        let (bounds_x, bounds_y) = ctx.bounds_self.get();
+        let (max_bounds_x, max_bounds_y) = (
+            self.bound_x.get().get_pixels(bounds_x),
+            self.bound_y.get().get_pixels(bounds_y),
+        );
+        let old_x = self.scroll_pos_x.get().to_float();
+        let old_y = self.scroll_pos_y.get().to_float();
+        let target_x = old_x + dx;
+        let target_y = old_y + dy;
+        let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
+        let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
+        self.scroll_pos_x.set(clamped_target_x.into());
+        self.scroll_pos_y.set(clamped_target_y.into());
+    }
+
+    pub fn add_momentum(&self, ddx: f64, ddy: f64) {
+        let mom_x = self.momentum_x.get();
+        let mom_y = self.momentum_y.get();
+        self.momentum_x.set(mom_x + ddx);
+        self.momentum_y.set(mom_y + ddy);
+    }
+
+    pub fn process_new_touch_pos(&self, ctx: &NodeContext, x: f64, y: f64, ident: i64) {
+        TOUCH_TRACKER.with_borrow_mut(|touches| {
+            let last = touches
+                .get_mut(&ident)
+                .expect("should have recieved touch down before touch move");
+            let delta_x = last.x - x;
+            let delta_y = last.y - y;
+            last.x = x;
+            last.y = y;
+            self.add_position(ctx, delta_x, delta_y);
+            self.add_momentum(delta_x, delta_y);
+        });
     }
 
     pub fn handle_wheel(&mut self, ctx: &NodeContext, args: Event<Wheel>) {
-        let (bounds_x, bounds_y) = ctx.bounds_self.get();
-        // - how to get the size of the content in the slot? (might need to be a primitive?)
-        //   or, pass in manually
-        let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
-        let old_x = self.scroll_pos_x.get();
-        let old_y = self.scroll_pos_y.get();
-        let target_x = old_x + args.delta_x;
-        let target_y = old_y + args.delta_y;
-        let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
-        let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
-        self.scroll_pos_x.set(clamped_target_x);
-        self.scroll_pos_y.set(clamped_target_y);
+        self.add_position(ctx, args.delta_x, args.delta_y);
     }
 
     pub fn touch_move(&mut self, ctx: &NodeContext, args: Event<TouchMove>) {
-        let args = args.touches.first().unwrap();
-        TOUCH_TRACKER.with_borrow_mut(|touches| {
-            let last = touches
-                .get_mut(&args.identifier)
-                .expect("should have recieved touch down before touch move");
-            let delta_x = last.x - args.x;
-            let delta_y = last.y - args.y;
-            last.x = args.x;
-            last.y = args.y;
-            let (bounds_x, bounds_y) = ctx.bounds_self.get();
-            let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
-            let old_x = self.scroll_pos_x.get();
-            let old_y = self.scroll_pos_y.get();
-            let target_x = old_x + delta_x;
-            let target_y = old_y + delta_y;
-            let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
-            let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
-            self.scroll_pos_x.set(clamped_target_x);
-            self.scroll_pos_y.set(clamped_target_y);
-            let mom_x = self.momentum_x.get();
-            let mom_y = self.momentum_y.get();
-            self.momentum_x.set(mom_x + delta_x);
-            self.momentum_y.set(mom_y + delta_y);
-        });
+        for touch in &args.touches {
+            self.process_new_touch_pos(ctx, touch.x, touch.y, touch.identifier);
+        }
     }
 
     pub fn touch_start(&mut self, _ctx: &NodeContext, args: Event<TouchStart>) {
         if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
-            let cached_damping = self.damping.get();
-            self.cached_damping.set(cached_damping);
-            self.damping.set(0.5);
+            let cached_damping = self.damping.get().to_float();
+            let temp_damping = cached_damping.max(0.5);
+            self.cached_damping.set(cached_damping.into());
+            self.damping.set(temp_damping.into());
         }
         self.momentum_x.set(0.0);
         self.momentum_y.set(0.0);
@@ -133,14 +141,17 @@ impl Scroller {
             );
         });
     }
-    pub fn touch_end(&mut self, _ctx: &NodeContext, args: Event<TouchEnd>) {
+    pub fn touch_end(&mut self, ctx: &NodeContext, args: Event<TouchEnd>) {
+        for touch in &args.touches {
+            self.process_new_touch_pos(ctx, touch.x, touch.y, touch.identifier);
+        }
         TOUCH_TRACKER.with_borrow_mut(|touches| {
             let idents: Vec<_> = args.touches.iter().map(|e| e.identifier).collect();
             touches.retain(|k, _| !idents.contains(k));
         });
         if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
             let cached_damping = self.cached_damping.get();
-            self.damping.set(cached_damping);
+            self.damping.set(cached_damping.into());
         }
     }
 }

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::primitives::PrimitiveScroller;
+use crate::primitives::Scrollbar;
 use crate::primitives::*;
 use crate::types::{StackerCell, StackerDirection};
 use pax_engine::api::Numeric;
@@ -17,19 +17,19 @@ use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, To
 #[pax]
 #[inlined(
     <Frame>
-        <PrimitiveScroller
+        <Scrollbar
             scroll_y={self.scroll_pos_y}
             width=20px
             anchor_x=100%
             x=100%
-            size_inner_pane_y={self.bound_y}
+            size_inner_pane_y={self.scroll_height}
         />
-        <PrimitiveScroller
+        <Scrollbar
             scroll_x={self.scroll_pos_x}
             height=20px
             anchor_y=100%
             y=100%
-            size_inner_pane_x={self.bound_x}
+            size_inner_pane_x={self.scroll_height}
         />
         <Group x={(-self.scroll_pos_x)px} y={(-self.scroll_pos_y)px}>
             for i in 0..self.slot_children {
@@ -52,8 +52,8 @@ use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, To
 pub struct Scroller {
     pub scroll_pos_x: Property<Numeric>,
     pub scroll_pos_y: Property<Numeric>,
-    pub bound_x: Property<Size>,
-    pub bound_y: Property<Size>,
+    pub scroll_width: Property<Size>,
+    pub scroll_height: Property<Size>,
 
     // private fields
     pub platform_params: Property<PlatformSpecificScrollParams>,
@@ -158,8 +158,8 @@ impl Scroller {
     pub fn add_position(&self, ctx: &NodeContext, dx: f64, dy: f64) {
         let (bounds_x, bounds_y) = ctx.bounds_self.get();
         let (max_bounds_x, max_bounds_y) = (
-            self.bound_x.get().get_pixels(bounds_x),
-            self.bound_y.get().get_pixels(bounds_y),
+            self.scroll_width.get().get_pixels(bounds_x),
+            self.scroll_height.get().get_pixels(bounds_y),
         );
         let old_x = self.scroll_pos_x.get().to_float();
         let old_y = self.scroll_pos_y.get().to_float();

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -1,0 +1,68 @@
+use crate::primitives::*;
+use crate::types::{StackerCell, StackerDirection};
+use pax_engine::api::Numeric;
+use pax_engine::api::{Event, Wheel};
+use pax_engine::api::{Property, Size, Transform2D};
+use pax_engine::*;
+use pax_runtime::api::{NodeContext, StringBox};
+/// Stacker lays out a series of nodes either
+/// vertically or horizontally (i.e. a single row or column) with a specified gutter in between
+/// each node.  `Stacker`s can be stacked inside of each other, horizontally
+/// and vertically, along with percentage-based positioning and `Transform2D.anchor` to compose any rectilinear 2D layout.
+#[pax]
+#[inlined(
+    <Frame>
+        <Group x={(-self.scroll_x)px} y={(-self.scroll_y)px}>
+            slot(0)
+        </Group>
+        <Rectangle fill=TRANSPARENT/>
+    </Frame>
+
+    @settings {
+        @mount: on_mount
+        @wheel: handle_wheel
+        @pre_render: update,
+    }
+
+)]
+pub struct Scroller {
+    pub scroll_x: Property<f64>,
+    pub scroll_y: Property<f64>,
+    pub target_x: Property<f64>,
+    pub target_y: Property<f64>,
+}
+
+// - how to not go to next page in Y direction? (args.prevent_default()?)
+
+impl Scroller {
+    pub fn on_mount(&mut self, _ctx: &NodeContext) {}
+
+    pub fn update(&mut self, ctx: &NodeContext) {
+        // const SOFT_COEF: f64 = 0.30;
+        // let soft_return_x =
+        //     self.scroll_x.get() * SOFT_COEF + self.target_x.get() * (1.0 - SOFT_COEF);
+        // let soft_return_y =
+        //     self.scroll_y.get() * SOFT_COEF + self.target_y.get() * (1.0 - SOFT_COEF);
+        // self.scroll_x.set(soft_return_x);
+        // self.scroll_y.set(soft_return_y);
+    }
+
+    pub fn handle_wheel(&mut self, ctx: &NodeContext, args: Event<Wheel>) {
+        let (bounds_x, bounds_y) = ctx.bounds_self.get();
+        // - how to get the size of the content in the slot? (might need to be a primitive?)
+        //   or, pass in manually
+        let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
+        let old_x = self.scroll_x.get();
+        let old_y = self.scroll_y.get();
+        let target_x = old_x + args.delta_x;
+        let target_y = old_y + args.delta_y;
+        let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
+        let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
+        self.scroll_x.set(clamped_target_x);
+        self.scroll_y.set(clamped_target_y);
+        // self.scroll_x.set(target_x);
+        // self.scroll_y.set(target_y);
+        // self.target_x.set(clamped_target_x);
+        // self.target_y.set(clamped_target_y);
+    }
+}

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -1,10 +1,13 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 use crate::primitives::*;
 use crate::types::{StackerCell, StackerDirection};
 use pax_engine::api::Numeric;
 use pax_engine::api::{Event, Wheel};
 use pax_engine::api::{Property, Size, Transform2D};
 use pax_engine::*;
-use pax_runtime::api::{NodeContext, StringBox};
+use pax_runtime::api::{NodeContext, StringBox, TouchEnd, TouchMove, TouchStart};
 /// Stacker lays out a series of nodes either
 /// vertically or horizontally (i.e. a single row or column) with a specified gutter in between
 /// each node.  `Stacker`s can be stacked inside of each other, horizontally
@@ -12,7 +15,7 @@ use pax_runtime::api::{NodeContext, StringBox};
 #[pax]
 #[inlined(
     <Frame>
-        <Group x={(-self.scroll_x)px} y={(-self.scroll_y)px}>
+        <Group x={(-self.scroll_pos_x)px} y={(-self.scroll_pos_y)px}>
             slot(0)
         </Group>
         <Rectangle fill=TRANSPARENT/>
@@ -22,29 +25,54 @@ use pax_runtime::api::{NodeContext, StringBox};
         @mount: on_mount
         @wheel: handle_wheel
         @pre_render: update,
+        @touch_move: touch_move,
+        @touch_start: touch_start,
+        @touch_end: touch_end,
     }
 
 )]
 pub struct Scroller {
-    pub scroll_x: Property<f64>,
-    pub scroll_y: Property<f64>,
-    pub target_x: Property<f64>,
-    pub target_y: Property<f64>,
+    pub scroll_pos_x: Property<f64>,
+    pub scroll_pos_y: Property<f64>,
+    pub momentum_x: Property<f64>,
+    pub momentum_y: Property<f64>,
+    pub damping: Property<f64>,
+    pub cached_damping: Property<f64>,
+}
+
+pub struct TouchInfo {
+    x: f64,
+    y: f64,
+}
+
+thread_local! {
+    static TOUCH_TRACKER: RefCell<HashMap<i64, TouchInfo>> = RefCell::new(HashMap::new());
 }
 
 // - how to not go to next page in Y direction? (args.prevent_default()?)
 
 impl Scroller {
-    pub fn on_mount(&mut self, _ctx: &NodeContext) {}
+    pub fn on_mount(&mut self, _ctx: &NodeContext) {
+        self.damping.set(0.90);
+    }
 
     pub fn update(&mut self, ctx: &NodeContext) {
-        // const SOFT_COEF: f64 = 0.30;
-        // let soft_return_x =
-        //     self.scroll_x.get() * SOFT_COEF + self.target_x.get() * (1.0 - SOFT_COEF);
-        // let soft_return_y =
-        //     self.scroll_y.get() * SOFT_COEF + self.target_y.get() * (1.0 - SOFT_COEF);
-        // self.scroll_x.set(soft_return_x);
-        // self.scroll_y.set(soft_return_y);
+        let mom_x = self.momentum_x.get();
+        let mom_y = self.momentum_y.get();
+        if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
+            let (bounds_x, bounds_y) = ctx.bounds_self.get();
+            let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
+            let old_x = self.scroll_pos_x.get();
+            let old_y = self.scroll_pos_y.get();
+            let target_x = old_x + mom_x;
+            let target_y = old_y + mom_y;
+            let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
+            let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
+            self.scroll_pos_x.set(clamped_target_x);
+            self.scroll_pos_y.set(clamped_target_y);
+        }
+        self.momentum_x.set(mom_x * self.damping.get());
+        self.momentum_y.set(mom_y * self.damping.get());
     }
 
     pub fn handle_wheel(&mut self, ctx: &NodeContext, args: Event<Wheel>) {
@@ -52,17 +80,67 @@ impl Scroller {
         // - how to get the size of the content in the slot? (might need to be a primitive?)
         //   or, pass in manually
         let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
-        let old_x = self.scroll_x.get();
-        let old_y = self.scroll_y.get();
+        let old_x = self.scroll_pos_x.get();
+        let old_y = self.scroll_pos_y.get();
         let target_x = old_x + args.delta_x;
         let target_y = old_y + args.delta_y;
         let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
         let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
-        self.scroll_x.set(clamped_target_x);
-        self.scroll_y.set(clamped_target_y);
-        // self.scroll_x.set(target_x);
-        // self.scroll_y.set(target_y);
-        // self.target_x.set(clamped_target_x);
-        // self.target_y.set(clamped_target_y);
+        self.scroll_pos_x.set(clamped_target_x);
+        self.scroll_pos_y.set(clamped_target_y);
+    }
+
+    pub fn touch_move(&mut self, ctx: &NodeContext, args: Event<TouchMove>) {
+        let args = args.touches.first().unwrap();
+        TOUCH_TRACKER.with_borrow_mut(|touches| {
+            let last = touches
+                .get_mut(&args.identifier)
+                .expect("should have recieved touch down before touch move");
+            let delta_x = last.x - args.x;
+            let delta_y = last.y - args.y;
+            last.x = args.x;
+            last.y = args.y;
+            let (bounds_x, bounds_y) = ctx.bounds_self.get();
+            let (max_bounds_x, max_bounds_y) = (bounds_x, bounds_y * 2.0); //temp
+            let old_x = self.scroll_pos_x.get();
+            let old_y = self.scroll_pos_y.get();
+            let target_x = old_x + delta_x;
+            let target_y = old_y + delta_y;
+            let clamped_target_x = target_x.clamp(0.0, max_bounds_x - bounds_x);
+            let clamped_target_y = target_y.clamp(0.0, max_bounds_y - bounds_y);
+            self.scroll_pos_x.set(clamped_target_x);
+            self.scroll_pos_y.set(clamped_target_y);
+            let mom_x = self.momentum_x.get();
+            let mom_y = self.momentum_y.get();
+            self.momentum_x.set(mom_x + delta_x);
+            self.momentum_y.set(mom_y + delta_y);
+        });
+    }
+
+    pub fn touch_start(&mut self, _ctx: &NodeContext, args: Event<TouchStart>) {
+        if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
+            let cached_damping = self.damping.get();
+            self.cached_damping.set(cached_damping);
+            self.damping.set(0.5);
+        }
+        self.momentum_x.set(0.0);
+        self.momentum_y.set(0.0);
+        TOUCH_TRACKER.with_borrow_mut(|touches| {
+            touches.extend(
+                args.touches
+                    .iter()
+                    .map(|e| (e.identifier, TouchInfo { x: e.x, y: e.y })),
+            );
+        });
+    }
+    pub fn touch_end(&mut self, _ctx: &NodeContext, args: Event<TouchEnd>) {
+        TOUCH_TRACKER.with_borrow_mut(|touches| {
+            let idents: Vec<_> = args.touches.iter().map(|e| e.identifier).collect();
+            touches.retain(|k, _| !idents.contains(k));
+        });
+        if TOUCH_TRACKER.with_borrow(|touches| touches.len() == 0) {
+            let cached_damping = self.cached_damping.get();
+            self.damping.set(cached_damping);
+        }
     }
 }

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -19,8 +19,17 @@ use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, To
     <Frame>
         <PrimitiveScroller 
             scroll_y={self.scroll_pos_y}
-            size_inner_pane_x={self.bound_x}
+            width=20px
+            anchor_x=100%
+            x=100%
             size_inner_pane_y={self.bound_y}
+        />
+        <PrimitiveScroller 
+            scroll_x={self.scroll_pos_x}
+            height=20px
+            anchor_y=100%
+            y=100%
+            size_inner_pane_x={self.bound_x}
         />
         <Group x={(-self.scroll_pos_x)px} y={(-self.scroll_pos_y)px}>
             slot(0)

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -17,14 +17,14 @@ use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, To
 #[pax]
 #[inlined(
     <Frame>
-        <PrimitiveScroller 
+        <PrimitiveScroller
             scroll_y={self.scroll_pos_y}
             width=20px
             anchor_x=100%
             x=100%
             size_inner_pane_y={self.bound_y}
         />
-        <PrimitiveScroller 
+        <PrimitiveScroller
             scroll_x={self.scroll_pos_x}
             height=20px
             anchor_y=100%
@@ -109,7 +109,6 @@ impl Scroller {
     }
 
     pub fn update(&mut self, ctx: &NodeContext) {
-
         if ctx.slot_children != self.slot_children.get() {
             self.slot_children.set(ctx.slot_children);
         }

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -32,7 +32,9 @@ use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, To
             size_inner_pane_x={self.bound_x}
         />
         <Group x={(-self.scroll_pos_x)px} y={(-self.scroll_pos_y)px}>
-            slot(0)
+            for i in 0..self.slot_children {
+                slot(i)
+            }
         </Group>
         <Rectangle fill=TRANSPARENT/>
     </Frame>
@@ -58,6 +60,7 @@ pub struct Scroller {
     pub momentum_x: Property<f64>,
     pub momentum_y: Property<f64>,
     pub damping: Property<f64>,
+    pub slot_children: Property<usize>,
 }
 
 #[pax]
@@ -106,6 +109,11 @@ impl Scroller {
     }
 
     pub fn update(&mut self, ctx: &NodeContext) {
+
+        if ctx.slot_children != self.slot_children.get() {
+            self.slot_children.set(ctx.slot_children);
+        }
+
         let mom_x = self.momentum_x.get();
         let mom_y = self.momentum_y.get();
         if no_touches() {


### PR DESCRIPTION
Scroller first pass

Missing: 
- scrollbars can't be used to scroll (do after double binding)
- Nested scrollbars need to communicate state and only scroll outer when
  inner is at end/beginning
- Multiple separate scrollbars on mobile results in buggy behavior: one "pauses" it's momentum propagation
  while another one is scrolled. (easy fix after private properties in pax structs)

Other features needed before complete:
- Frame clipping of native elements
- Correct ray cast behavior on elements hidden by frame