### PR TITLE
Refactor Parsing Errors to use pest updated errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ members = [
     "pax-std/pax-std-primitives",
     "pax-manifest",
     "pax-lang",
+    "pax-language-server",
 ]
 
 exclude = [
     "pax-cartridge",
     "pax-compiler/new-project-template",
     "pax-create-sandbox",
-    "pax-language-server",
     "examples",
     "www.pax.dev/src/website",
 ]

--- a/examples/src/fireworks/Cargo.toml
+++ b/examples/src/fireworks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.6" }
-pax-std = { version = "0.14.6" }
-pax-compiler = { version = "0.14.6", optional = true }
-pax-manifest = { version = "0.14.6" }
+pax-engine = { version = "0.14.7" }
+pax-std = { version = "0.14.7" }
+pax-compiler = { version = "0.14.7", optional = true }
+pax-manifest = { version = "0.14.7" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/fireworks/Cargo.toml
+++ b/examples/src/fireworks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.7" }
-pax-std = { version = "0.14.7" }
-pax-compiler = { version = "0.14.7", optional = true }
-pax-manifest = { version = "0.14.7" }
+pax-engine = { version = "0.14.8" }
+pax-std = { version = "0.14.8" }
+pax-compiler = { version = "0.14.8", optional = true }
+pax-manifest = { version = "0.14.8" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/fireworks/Cargo.toml
+++ b/examples/src/fireworks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.5" }
-pax-std = { version = "0.14.5" }
-pax-compiler = { version = "0.14.5", optional = true }
-pax-manifest = { version = "0.14.5" }
+pax-engine = { version = "0.14.6" }
+pax-std = { version = "0.14.6" }
+pax-compiler = { version = "0.14.6", optional = true }
+pax-manifest = { version = "0.14.6" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/fireworks/Cargo.toml
+++ b/examples/src/fireworks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.4" }
-pax-std = { version = "0.14.4" }
-pax-compiler = { version = "0.14.4", optional = true }
-pax-manifest = { version = "0.14.4" }
+pax-engine = { version = "0.14.5" }
+pax-std = { version = "0.14.5" }
+pax-compiler = { version = "0.14.5", optional = true }
+pax-manifest = { version = "0.14.5" }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/mouse-animation/Cargo.toml
+++ b/examples/src/mouse-animation/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.5"}
-pax-std = { version = "0.14.5"}
-pax-compiler = { version = "0.14.5", optional = true }
-pax-manifest = { version = "0.14.5", optional = true }
+pax-engine = { version = "0.14.6"}
+pax-std = { version = "0.14.6"}
+pax-compiler = { version = "0.14.6", optional = true }
+pax-manifest = { version = "0.14.6", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/mouse-animation/Cargo.toml
+++ b/examples/src/mouse-animation/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.4"}
-pax-std = { version = "0.14.4"}
-pax-compiler = { version = "0.14.4", optional = true }
-pax-manifest = { version = "0.14.4", optional = true }
+pax-engine = { version = "0.14.5"}
+pax-std = { version = "0.14.5"}
+pax-compiler = { version = "0.14.5", optional = true }
+pax-manifest = { version = "0.14.5", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/mouse-animation/Cargo.toml
+++ b/examples/src/mouse-animation/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.6"}
-pax-std = { version = "0.14.6"}
-pax-compiler = { version = "0.14.6", optional = true }
-pax-manifest = { version = "0.14.6", optional = true }
+pax-engine = { version = "0.14.7"}
+pax-std = { version = "0.14.7"}
+pax-compiler = { version = "0.14.7", optional = true }
+pax-manifest = { version = "0.14.7", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/mouse-animation/Cargo.toml
+++ b/examples/src/mouse-animation/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.7"}
-pax-std = { version = "0.14.7"}
-pax-compiler = { version = "0.14.7", optional = true }
-pax-manifest = { version = "0.14.7", optional = true }
+pax-engine = { version = "0.14.8"}
+pax-std = { version = "0.14.8"}
+pax-compiler = { version = "0.14.8", optional = true }
+pax-manifest = { version = "0.14.8", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 
 [[bin]]

--- a/examples/src/particles/Cargo.toml
+++ b/examples/src/particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.6" }
-pax-std = { version = "0.14.6" }
-pax-compiler = { version = "0.14.6", optional = true}
-pax-manifest = { version = "0.14.6", optional = true}
+pax-engine = { version = "0.14.7" }
+pax-std = { version = "0.14.7" }
+pax-compiler = { version = "0.14.7", optional = true}
+pax-manifest = { version = "0.14.7", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 rand = { version = "0.8.5" }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/src/particles/Cargo.toml
+++ b/examples/src/particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.7" }
-pax-std = { version = "0.14.7" }
-pax-compiler = { version = "0.14.7", optional = true}
-pax-manifest = { version = "0.14.7", optional = true}
+pax-engine = { version = "0.14.8" }
+pax-std = { version = "0.14.8" }
+pax-compiler = { version = "0.14.8", optional = true}
+pax-manifest = { version = "0.14.8", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 rand = { version = "0.8.5" }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/src/particles/Cargo.toml
+++ b/examples/src/particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.4" }
-pax-std = { version = "0.14.4" }
-pax-compiler = { version = "0.14.4", optional = true}
-pax-manifest = { version = "0.14.4", optional = true}
+pax-engine = { version = "0.14.5" }
+pax-std = { version = "0.14.5" }
+pax-compiler = { version = "0.14.5", optional = true}
+pax-manifest = { version = "0.14.5", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 rand = { version = "0.8.5" }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/src/particles/Cargo.toml
+++ b/examples/src/particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.5" }
-pax-std = { version = "0.14.5" }
-pax-compiler = { version = "0.14.5", optional = true}
-pax-manifest = { version = "0.14.5", optional = true}
+pax-engine = { version = "0.14.6" }
+pax-std = { version = "0.14.6" }
+pax-compiler = { version = "0.14.6", optional = true}
+pax-manifest = { version = "0.14.6", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 rand = { version = "0.8.5" }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/src/slot-particles/Cargo.toml
+++ b/examples/src/slot-particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.5"}
-pax-std = { version = "0.14.5"}
-pax-compiler = { version = "0.14.5", optional = true }
-pax-manifest = { version = "0.14.5", optional = true }
+pax-engine = { version = "0.14.6"}
+pax-std = { version = "0.14.6"}
+pax-compiler = { version = "0.14.6", optional = true }
+pax-manifest = { version = "0.14.6", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/slot-particles/Cargo.toml
+++ b/examples/src/slot-particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.4"}
-pax-std = { version = "0.14.4"}
-pax-compiler = { version = "0.14.4", optional = true }
-pax-manifest = { version = "0.14.4", optional = true }
+pax-engine = { version = "0.14.5"}
+pax-std = { version = "0.14.5"}
+pax-compiler = { version = "0.14.5", optional = true }
+pax-manifest = { version = "0.14.5", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/slot-particles/Cargo.toml
+++ b/examples/src/slot-particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.7"}
-pax-std = { version = "0.14.7"}
-pax-compiler = { version = "0.14.7", optional = true }
-pax-manifest = { version = "0.14.7", optional = true }
+pax-engine = { version = "0.14.8"}
+pax-std = { version = "0.14.8"}
+pax-compiler = { version = "0.14.8", optional = true }
+pax-manifest = { version = "0.14.8", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/slot-particles/Cargo.toml
+++ b/examples/src/slot-particles/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.6"}
-pax-std = { version = "0.14.6"}
-pax-compiler = { version = "0.14.6", optional = true }
-pax-manifest = { version = "0.14.6", optional = true }
+pax-engine = { version = "0.14.7"}
+pax-std = { version = "0.14.7"}
+pax-compiler = { version = "0.14.7", optional = true }
+pax-manifest = { version = "0.14.7", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/space-game/Cargo.toml
+++ b/examples/src/space-game/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.5"}
-pax-std = { version = "0.14.5"}
-pax-compiler = { version = "0.14.5", optional = true }
-pax-manifest = { version = "0.14.5", optional = true }
+pax-engine = { version = "0.14.6"}
+pax-std = { version = "0.14.6"}
+pax-compiler = { version = "0.14.6", optional = true }
+pax-manifest = { version = "0.14.6", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/space-game/Cargo.toml
+++ b/examples/src/space-game/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.4"}
-pax-std = { version = "0.14.4"}
-pax-compiler = { version = "0.14.4", optional = true }
-pax-manifest = { version = "0.14.4", optional = true }
+pax-engine = { version = "0.14.5"}
+pax-std = { version = "0.14.5"}
+pax-compiler = { version = "0.14.5", optional = true }
+pax-manifest = { version = "0.14.5", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/space-game/Cargo.toml
+++ b/examples/src/space-game/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.7"}
-pax-std = { version = "0.14.7"}
-pax-compiler = { version = "0.14.7", optional = true }
-pax-manifest = { version = "0.14.7", optional = true }
+pax-engine = { version = "0.14.8"}
+pax-std = { version = "0.14.8"}
+pax-compiler = { version = "0.14.8", optional = true }
+pax-manifest = { version = "0.14.8", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/space-game/Cargo.toml
+++ b/examples/src/space-game/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 default-run = "run"
 
 [dependencies]
-pax-engine = { version = "0.14.6"}
-pax-std = { version = "0.14.6"}
-pax-compiler = { version = "0.14.6", optional = true }
-pax-manifest = { version = "0.14.6", optional = true }
+pax-engine = { version = "0.14.7"}
+pax-std = { version = "0.14.7"}
+pax-compiler = { version = "0.14.7", optional = true }
+pax-manifest = { version = "0.14.7", optional = true }
 serde_json = {version = "1.0.95", optional = true}
 rand = {version = "0.8.5"}
 getrandom = { version = "0.2.14", features = ["js"] }

--- a/examples/src/space-game/src/lib.pax
+++ b/examples/src/space-game/src/lib.pax
@@ -15,6 +15,8 @@ if self.game_state == "GAME_OVER" {
 			width=32px
 			height=32px
 			path="assets/spaceship.png"
+			anchor_x=50%
+			anchor_y=50%
 			x={self.ship_x}
 			y={self.ship_y}
 		/>
@@ -23,6 +25,8 @@ if self.game_state == "GAME_OVER" {
 	for asteroid in self.asteroids {
 		<Image
 			path={asteroid.animation.frame}
+			anchor_x=50%
+			anchor_y=50%
 			x={asteroid.x}
 			y={asteroid.y}
 			width={asteroid.w}
@@ -35,6 +39,8 @@ if self.game_state == "GAME_OVER" {
 			width=16px
 			height=16px
 			path="assets/bullet.png"
+			anchor_x=50%
+			anchor_y=50%
 			x={bullet.x}
 			y={bullet.y}
 		/>

--- a/pax-cartridge/Cargo.toml
+++ b/pax-cartridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cartridge"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ default = ["pax-manifest/parsing"]
 
 [dependencies]
 piet-common = "0.6.0"
-pax-runtime = {path = "../pax-runtime", version = "0.14.5"}
-pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.5"}
-pax-engine = {path = "../pax-engine", version = "0.14.5"}
-pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.5"}
-pax-manifest = {path = "../pax-manifest", version = "0.14.5"}
+pax-runtime = {path = "../pax-runtime", version = "0.14.6"}
+pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.6"}
+pax-engine = {path = "../pax-engine", version = "0.14.6"}
+pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.6"}
+pax-manifest = {path = "../pax-manifest", version = "0.14.6"}
 serde_json = "1.0.95"
 
 [profile.release]

--- a/pax-cartridge/Cargo.toml
+++ b/pax-cartridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cartridge"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ default = ["pax-manifest/parsing"]
 
 [dependencies]
 piet-common = "0.6.0"
-pax-runtime = {path = "../pax-runtime", version = "0.14.4"}
-pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.4"}
-pax-engine = {path = "../pax-engine", version = "0.14.4"}
-pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.4"}
-pax-manifest = {path = "../pax-manifest", version = "0.14.4"}
+pax-runtime = {path = "../pax-runtime", version = "0.14.5"}
+pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.5"}
+pax-engine = {path = "../pax-engine", version = "0.14.5"}
+pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.5"}
+pax-manifest = {path = "../pax-manifest", version = "0.14.5"}
 serde_json = "1.0.95"
 
 [profile.release]

--- a/pax-cartridge/Cargo.toml
+++ b/pax-cartridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cartridge"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ default = ["pax-manifest/parsing"]
 
 [dependencies]
 piet-common = "0.6.0"
-pax-runtime = {path = "../pax-runtime", version = "0.14.7"}
-pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.7"}
-pax-engine = {path = "../pax-engine", version = "0.14.7"}
-pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.7"}
-pax-manifest = {path = "../pax-manifest", version = "0.14.7"}
+pax-runtime = {path = "../pax-runtime", version = "0.14.8"}
+pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.8"}
+pax-engine = {path = "../pax-engine", version = "0.14.8"}
+pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.8"}
+pax-manifest = {path = "../pax-manifest", version = "0.14.8"}
 serde_json = "1.0.95"
 
 [profile.release]

--- a/pax-cartridge/Cargo.toml
+++ b/pax-cartridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cartridge"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ default = ["pax-manifest/parsing"]
 
 [dependencies]
 piet-common = "0.6.0"
-pax-runtime = {path = "../pax-runtime", version = "0.14.6"}
-pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.6"}
-pax-engine = {path = "../pax-engine", version = "0.14.6"}
-pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.6"}
-pax-manifest = {path = "../pax-manifest", version = "0.14.6"}
+pax-runtime = {path = "../pax-runtime", version = "0.14.7"}
+pax-runtime-api = {path = "../pax-runtime-api", version = "0.14.7"}
+pax-engine = {path = "../pax-engine", version = "0.14.7"}
+pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.14.7"}
+pax-manifest = {path = "../pax-manifest", version = "0.14.7"}
 serde_json = "1.0.95"
 
 [profile.release]

--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-common"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 description = "Shared resources for Pax Chassis"
@@ -16,9 +16,9 @@ exclude = ["pax-swift-common/.build"]
 env_logger = "0.11.1"
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.5" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
-pax-message = {path = "../pax-message", version="0.14.5"}
+pax-runtime = { path = "../pax-runtime", version="0.14.6" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
+pax-message = {path = "../pax-message", version="0.14.6"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-common"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 description = "Shared resources for Pax Chassis"
@@ -16,9 +16,9 @@ exclude = ["pax-swift-common/.build"]
 env_logger = "0.11.1"
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.4" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.4"}
-pax-message = {path = "../pax-message", version="0.14.4"}
+pax-runtime = { path = "../pax-runtime", version="0.14.5" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
+pax-message = {path = "../pax-message", version="0.14.5"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-common"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 description = "Shared resources for Pax Chassis"
@@ -16,9 +16,9 @@ exclude = ["pax-swift-common/.build"]
 env_logger = "0.11.1"
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.6" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
-pax-message = {path = "../pax-message", version="0.14.6"}
+pax-runtime = { path = "../pax-runtime", version="0.14.7" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
+pax-message = {path = "../pax-message", version="0.14.7"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-common"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 description = "Shared resources for Pax Chassis"
@@ -16,9 +16,9 @@ exclude = ["pax-swift-common/.build"]
 env_logger = "0.11.1"
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.7" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
-pax-message = {path = "../pax-message", version="0.14.7"}
+pax-runtime = { path = "../pax-runtime", version="0.14.8" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.8"}
+pax-message = {path = "../pax-message", version="0.14.8"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-ios/Cargo.toml
+++ b/pax-chassis-ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-ios"
 edition = "2021"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -13,4 +13,4 @@ name = "paxchassisios"
 crate-type = ["cdylib"]
 
 [dependencies]
-pax-chassis-common = {version = "0.14.6", path="../pax-chassis-common"}
+pax-chassis-common = {version = "0.14.7", path="../pax-chassis-common"}

--- a/pax-chassis-ios/Cargo.toml
+++ b/pax-chassis-ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-ios"
 edition = "2021"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -13,4 +13,4 @@ name = "paxchassisios"
 crate-type = ["cdylib"]
 
 [dependencies]
-pax-chassis-common = {version = "0.14.5", path="../pax-chassis-common"}
+pax-chassis-common = {version = "0.14.6", path="../pax-chassis-common"}

--- a/pax-chassis-ios/Cargo.toml
+++ b/pax-chassis-ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-ios"
 edition = "2021"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -13,4 +13,4 @@ name = "paxchassisios"
 crate-type = ["cdylib"]
 
 [dependencies]
-pax-chassis-common = {version = "0.14.4", path="../pax-chassis-common"}
+pax-chassis-common = {version = "0.14.5", path="../pax-chassis-common"}

--- a/pax-chassis-ios/Cargo.toml
+++ b/pax-chassis-ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-ios"
 edition = "2021"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -13,4 +13,4 @@ name = "paxchassisios"
 crate-type = ["cdylib"]
 
 [dependencies]
-pax-chassis-common = {version = "0.14.7", path="../pax-chassis-common"}
+pax-chassis-common = {version = "0.14.8", path="../pax-chassis-common"}

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-macos"
 edition = "2021"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-chassis-common = { path = "../pax-chassis-common", version="0.14.5" }
-pax-runtime = { path = "../pax-runtime", version="0.14.5" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
-pax-message = {path = "../pax-message", version="0.14.5"}
+pax-chassis-common = { path = "../pax-chassis-common", version="0.14.6" }
+pax-runtime = { path = "../pax-runtime", version="0.14.6" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
+pax-message = {path = "../pax-message", version="0.14.6"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-macos"
 edition = "2021"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-chassis-common = { path = "../pax-chassis-common", version="0.14.6" }
-pax-runtime = { path = "../pax-runtime", version="0.14.6" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
-pax-message = {path = "../pax-message", version="0.14.6"}
+pax-chassis-common = { path = "../pax-chassis-common", version="0.14.7" }
+pax-runtime = { path = "../pax-runtime", version="0.14.7" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
+pax-message = {path = "../pax-message", version="0.14.7"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-macos"
 edition = "2021"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-chassis-common = { path = "../pax-chassis-common", version="0.14.7" }
-pax-runtime = { path = "../pax-runtime", version="0.14.7" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
-pax-message = {path = "../pax-message", version="0.14.7"}
+pax-chassis-common = { path = "../pax-chassis-common", version="0.14.8" }
+pax-runtime = { path = "../pax-runtime", version="0.14.8" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.8"}
+pax-message = {path = "../pax-message", version="0.14.8"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-macos"
 edition = "2021"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-chassis-common = { path = "../pax-chassis-common", version="0.14.4" }
-pax-runtime = { path = "../pax-runtime", version="0.14.4" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.4"}
-pax-message = {path = "../pax-message", version="0.14.4"}
+pax-chassis-common = { path = "../pax-chassis-common", version="0.14.5" }
+pax-runtime = { path = "../pax-runtime", version="0.14.5" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
+pax-message = {path = "../pax-message", version="0.14.5"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-web"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ default = ["console_error_panic_hook"]
 [dependencies]
 piet = "0.6.0"
 piet-web = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.7" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
-pax-message = {path = "../pax-message", version="0.14.7"}
+pax-runtime = { path = "../pax-runtime", version="0.14.8" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.8"}
+pax-message = {path = "../pax-message", version="0.14.8"}
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
 console_log = "1.0.0"

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-web"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ default = ["console_error_panic_hook"]
 [dependencies]
 piet = "0.6.0"
 piet-web = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.6" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
-pax-message = {path = "../pax-message", version="0.14.6"}
+pax-runtime = { path = "../pax-runtime", version="0.14.7" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.7"}
+pax-message = {path = "../pax-message", version="0.14.7"}
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
 console_log = "1.0.0"

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-web"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ default = ["console_error_panic_hook"]
 [dependencies]
 piet = "0.6.0"
 piet-web = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.5" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
-pax-message = {path = "../pax-message", version="0.14.5"}
+pax-runtime = { path = "../pax-runtime", version="0.14.6" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.6"}
+pax-message = {path = "../pax-message", version="0.14.6"}
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
 console_log = "1.0.0"

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-web"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ default = ["console_error_panic_hook"]
 [dependencies]
 piet = "0.6.0"
 piet-web = "0.6.0"
-pax-runtime = { path = "../pax-runtime", version="0.14.4" }
-pax-cartridge = {path="../pax-cartridge", version="0.14.4"}
-pax-message = {path = "../pax-message", version="0.14.4"}
+pax-runtime = { path = "../pax-runtime", version="0.14.5" }
+pax-cartridge = {path="../pax-cartridge", version="0.14.5"}
+pax-message = {path = "../pax-message", version="0.14.5"}
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
 console_log = "1.0.0"

--- a/pax-cli/Cargo.toml
+++ b/pax-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cli"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ description = "Command line interface tool for developing, packaging, and managi
 
 [dependencies]
 clap = "2.33.3"
-pax-compiler = {path = "../pax-compiler", version = "0.14.4"}
-pax-language-server = {version = "0.14.4"}
+pax-compiler = {path = "../pax-compiler", version = "0.14.5"}
+pax-language-server = {version = "0.14.5"}
 rustc_version = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0.0"

--- a/pax-cli/Cargo.toml
+++ b/pax-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cli"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ description = "Command line interface tool for developing, packaging, and managi
 
 [dependencies]
 clap = "2.33.3"
-pax-compiler = {path = "../pax-compiler", version = "0.14.5"}
-pax-language-server = {version = "0.14.5"}
+pax-compiler = {path = "../pax-compiler", version = "0.14.6"}
+pax-language-server = {version = "0.14.6"}
 rustc_version = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0.0"

--- a/pax-cli/Cargo.toml
+++ b/pax-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cli"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ description = "Command line interface tool for developing, packaging, and managi
 
 [dependencies]
 clap = "2.33.3"
-pax-compiler = {path = "../pax-compiler", version = "0.14.6"}
-pax-language-server = {version = "0.14.6"}
+pax-compiler = {path = "../pax-compiler", version = "0.14.7"}
+pax-language-server = {version = "0.14.7"}
 rustc_version = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0.0"

--- a/pax-cli/Cargo.toml
+++ b/pax-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cli"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ description = "Command line interface tool for developing, packaging, and managi
 
 [dependencies]
 clap = "2.33.3"
-pax-compiler = {path = "../pax-compiler", version = "0.14.7"}
-pax-language-server = {version = "0.14.7"}
+pax-compiler = {path = "../pax-compiler", version = "0.14.8"}
+pax-language-server = {version = "0.14.8"}
 rustc_version = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0.0"

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-compiler"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -41,13 +41,13 @@ lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
 nix = "0.20.2"
-pax-manifest = {version= "0.14.6", path="../pax-manifest"}
-pax-message = {version = "0.14.6", path="../pax-message"}
-pax-runtime = {path = "../pax-runtime", version="0.14.6" }
-pax-runtime-api = {path = "../pax-runtime-api", version="0.14.6" }
+pax-manifest = {version= "0.14.7", path="../pax-manifest"}
+pax-message = {version = "0.14.7", path="../pax-message"}
+pax-runtime = {path = "../pax-runtime", version="0.14.7" }
+pax-runtime-api = {path = "../pax-runtime-api", version="0.14.7" }
 portpicker = "0.1.1"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-pax-lang = {version = "0.14.6", path="../pax-lang"}
+pax-lang = {version = "0.14.7", path="../pax-lang"}
 rand = "0.8.4"
 regex = "1"
 reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-compiler"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -41,13 +41,13 @@ lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
 nix = "0.20.2"
-pax-manifest = {version= "0.14.4", path="../pax-manifest"}
-pax-message = {version = "0.14.4", path="../pax-message"}
-pax-runtime = {path = "../pax-runtime", version="0.14.4" }
-pax-runtime-api = {path = "../pax-runtime-api", version="0.14.4" }
+pax-manifest = {version= "0.14.5", path="../pax-manifest"}
+pax-message = {version = "0.14.5", path="../pax-message"}
+pax-runtime = {path = "../pax-runtime", version="0.14.5" }
+pax-runtime-api = {path = "../pax-runtime-api", version="0.14.5" }
 portpicker = "0.1.1"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-pax-lang = {version = "0.14.4", path="../pax-lang"}
+pax-lang = {version = "0.14.5", path="../pax-lang"}
 rand = "0.8.4"
 regex = "1"
 reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-compiler"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -41,13 +41,13 @@ lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
 nix = "0.20.2"
-pax-manifest = {version= "0.14.7", path="../pax-manifest"}
-pax-message = {version = "0.14.7", path="../pax-message"}
-pax-runtime = {path = "../pax-runtime", version="0.14.7" }
-pax-runtime-api = {path = "../pax-runtime-api", version="0.14.7" }
+pax-manifest = {version= "0.14.8", path="../pax-manifest"}
+pax-message = {version = "0.14.8", path="../pax-message"}
+pax-runtime = {path = "../pax-runtime", version="0.14.8" }
+pax-runtime-api = {path = "../pax-runtime-api", version="0.14.8" }
 portpicker = "0.1.1"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-pax-lang = {version = "0.14.7", path="../pax-lang"}
+pax-lang = {version = "0.14.8", path="../pax-lang"}
 rand = "0.8.4"
 regex = "1"
 reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-compiler"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -41,13 +41,13 @@ lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
 nix = "0.20.2"
-pax-manifest = {version= "0.14.5", path="../pax-manifest"}
-pax-message = {version = "0.14.5", path="../pax-message"}
-pax-runtime = {path = "../pax-runtime", version="0.14.5" }
-pax-runtime-api = {path = "../pax-runtime-api", version="0.14.5" }
+pax-manifest = {version= "0.14.6", path="../pax-manifest"}
+pax-message = {version = "0.14.6", path="../pax-message"}
+pax-runtime = {path = "../pax-runtime", version="0.14.6" }
+pax-runtime-api = {path = "../pax-runtime-api", version="0.14.6" }
 portpicker = "0.1.1"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-pax-lang = {version = "0.14.5", path="../pax-lang"}
+pax-lang = {version = "0.14.6", path="../pax-lang"}
 rand = "0.8.4"
 regex = "1"
 reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/pax-compiler/src/formatting/mod.rs
+++ b/pax-compiler/src/formatting/mod.rs
@@ -2,16 +2,14 @@ mod rules;
 
 use crate::helpers::{replace_by_line_column, InlinedTemplateFinder};
 use color_eyre::eyre::{self, Report};
-use pax_lang::{Parser, PaxParser, Rule};
+use pax_lang::{parse_pax_err, Rule};
 use std::fs;
 use std::path::Path;
 use syn::parse_file;
 use syn::visit::Visit;
 
 pub fn format_pax_template(code: String) -> Result<String, eyre::Report> {
-    let pax_component_definition = PaxParser::parse(Rule::pax_component_definition, code.as_str())?
-        .next()
-        .unwrap();
+    let pax_component_definition = parse_pax_err(Rule::pax_component_definition, code.as_str())?;
     Ok(rules::format(pax_component_definition))
 }
 

--- a/pax-compiler/src/formatting/rules.rs
+++ b/pax-compiler/src/formatting/rules.rs
@@ -180,18 +180,9 @@ fn get_formatting_rules(pest_rule: Rule) -> Vec<Box<dyn FormattingRule>> {
         | Rule::any_tag_pair
         | Rule::WHITESPACE
         | Rule::id
-        | Rule::silent_comma
-        | Rule::empty => vec![Box::new(IgnoreRule)],
+        | Rule::silent_comma => vec![Box::new(IgnoreRule)],
 
         Rule::string => vec![Box::new(DoNotIndentRule)],
-
-        Rule::inner_tag_error
-        | Rule::selector_block_error
-        | Rule::attribute_key_value_pair_error
-        | Rule::tag_error
-        | Rule::open_tag_error
-        | Rule::block_level_error
-        | Rule::expression_body_error => vec![Box::new(PanicRule)],
     }
 }
 
@@ -873,7 +864,6 @@ impl FormattingRule for WrapExpressionRule {
     fn is_applicable(&self, children: Vec<Child>) -> bool {
         if children.len() == 1 {
             if children[0].node_type == Rule::expression_body
-                || children[0].node_type == Rule::expression_body_error
             {
                 return true;
             }

--- a/pax-compiler/src/formatting/rules.rs
+++ b/pax-compiler/src/formatting/rules.rs
@@ -863,8 +863,7 @@ struct WrapExpressionRule;
 impl FormattingRule for WrapExpressionRule {
     fn is_applicable(&self, children: Vec<Child>) -> bool {
         if children.len() == 1 {
-            if children[0].node_type == Rule::expression_body
-            {
+            if children[0].node_type == Rule::expression_body {
                 return true;
             }
         }

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -941,7 +941,10 @@ fn derive_value_definition_from_literal_object_pair(
     }
 }
 
-pub fn parse_settings_from_component_definition_string(pax: &str, pax_component_definition: Pair<Rule>) -> Vec<SettingsBlockElement> {
+pub fn parse_settings_from_component_definition_string(
+    pax: &str,
+    pax_component_definition: Pair<Rule>,
+) -> Vec<SettingsBlockElement> {
     let mut settings: Vec<SettingsBlockElement> = vec![];
 
     pax_component_definition
@@ -1084,8 +1087,7 @@ pub fn assemble_component_definition(
         ),
     };
 
-    let ast = parse_pax_str(Rule::pax_component_definition, pax)
-        .expect("Unsuccessful parse");
+    let ast = parse_pax_str(Rule::pax_component_definition, pax).expect("Unsuccessful parse");
 
     parse_template_from_component_definition_string(&mut tpc, pax, ast.clone());
     let modified_module_path = if module_path.starts_with("parser") {

--- a/pax-engine/Cargo.toml
+++ b/pax-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-engine"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ description = "Root import entry-point for using Pax in a Rust program"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-macro = {path="../pax-macro", version="0.14.6"}
-pax-message = {path="../pax-message", version="0.14.6"}
-pax-runtime = {path="../pax-runtime", version="0.14.6"}
-pax-compiler = {path="../pax-compiler", optional=true, version="0.14.6"}
+pax-macro = {path="../pax-macro", version="0.14.7"}
+pax-message = {path="../pax-message", version="0.14.7"}
+pax-runtime = {path="../pax-runtime", version="0.14.7"}
+pax-compiler = {path="../pax-compiler", optional=true, version="0.14.7"}
 log = "0.4.20"
 
 [features]

--- a/pax-engine/Cargo.toml
+++ b/pax-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-engine"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ description = "Root import entry-point for using Pax in a Rust program"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-macro = {path="../pax-macro", version="0.14.5"}
-pax-message = {path="../pax-message", version="0.14.5"}
-pax-runtime = {path="../pax-runtime", version="0.14.5"}
-pax-compiler = {path="../pax-compiler", optional=true, version="0.14.5"}
+pax-macro = {path="../pax-macro", version="0.14.6"}
+pax-message = {path="../pax-message", version="0.14.6"}
+pax-runtime = {path="../pax-runtime", version="0.14.6"}
+pax-compiler = {path="../pax-compiler", optional=true, version="0.14.6"}
 log = "0.4.20"
 
 [features]

--- a/pax-engine/Cargo.toml
+++ b/pax-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-engine"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ description = "Root import entry-point for using Pax in a Rust program"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-macro = {path="../pax-macro", version="0.14.4"}
-pax-message = {path="../pax-message", version="0.14.4"}
-pax-runtime = {path="../pax-runtime", version="0.14.4"}
-pax-compiler = {path="../pax-compiler", optional=true, version="0.14.4"}
+pax-macro = {path="../pax-macro", version="0.14.5"}
+pax-message = {path="../pax-message", version="0.14.5"}
+pax-runtime = {path="../pax-runtime", version="0.14.5"}
+pax-compiler = {path="../pax-compiler", optional=true, version="0.14.5"}
 log = "0.4.20"
 
 [features]

--- a/pax-engine/Cargo.toml
+++ b/pax-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-engine"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ description = "Root import entry-point for using Pax in a Rust program"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-macro = {path="../pax-macro", version="0.14.7"}
-pax-message = {path="../pax-message", version="0.14.7"}
-pax-runtime = {path="../pax-runtime", version="0.14.7"}
-pax-compiler = {path="../pax-compiler", optional=true, version="0.14.7"}
+pax-macro = {path="../pax-macro", version="0.14.8"}
+pax-message = {path="../pax-message", version="0.14.8"}
+pax-runtime = {path="../pax-runtime", version="0.14.8"}
+pax-compiler = {path="../pax-compiler", optional=true, version="0.14.8"}
 log = "0.4.20"
 
 [features]

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-lang"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -11,5 +11,5 @@ description = "Pax language parser"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = {version = "2.7.10", features = ["std"]}
+pest_derive = {version = "2.7.10", features = ["std"]}

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-lang"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-lang"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-lang"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-lang/src/lib.rs
+++ b/pax-lang/src/lib.rs
@@ -1,3 +1,4 @@
+use pest::error::Error;
 pub use pest::iterators::{Pair, Pairs};
 
 pub use pest::pratt_parser::{Assoc, Op, PrattParser};
@@ -7,3 +8,29 @@ pub use pest_derive::Parser;
 #[derive(Parser)]
 #[grammar = "pax.pest"]
 pub struct PaxParser;
+
+pub fn parse_pax_str(expected_rule: Rule, input: &str) -> Result<Pair<Rule>, String> {
+    let pairs = PaxParser::parse(expected_rule, input);
+    match pairs {
+        Ok(mut pairs) => {
+            let pair = pairs.next().unwrap();
+            Ok(pair)
+        }
+        Err(err) => {
+            Err(format!("{err}"))
+        }
+    }
+} 
+
+pub fn parse_pax_err(expected_rule: Rule, input: &str) -> Result<Pair<Rule>, Error<Rule>> {
+    let pairs = PaxParser::parse(expected_rule, input);
+    match pairs {
+        Ok(mut pairs) => {
+            let pair = pairs.next().unwrap();
+            Ok(pair)
+        }
+        Err(err) => {
+            Err(err)
+        }
+    }
+}

--- a/pax-lang/src/lib.rs
+++ b/pax-lang/src/lib.rs
@@ -16,11 +16,9 @@ pub fn parse_pax_str(expected_rule: Rule, input: &str) -> Result<Pair<Rule>, Str
             let pair = pairs.next().unwrap();
             Ok(pair)
         }
-        Err(err) => {
-            Err(format!("{err}"))
-        }
+        Err(err) => Err(format!("{err}")),
     }
-} 
+}
 
 pub fn parse_pax_err(expected_rule: Rule, input: &str) -> Result<Pair<Rule>, Error<Rule>> {
     let pairs = PaxParser::parse(expected_rule, input);
@@ -29,8 +27,6 @@ pub fn parse_pax_err(expected_rule: Rule, input: &str) -> Result<Pair<Rule>, Err
             let pair = pairs.next().unwrap();
             Ok(pair)
         }
-        Err(err) => {
-            Err(err)
-        }
+        Err(err) => Err(err),
     }
 }

--- a/pax-lang/src/pax.pest
+++ b/pax-lang/src/pax.pest
@@ -13,30 +13,23 @@ comment = @{  ( "/*" ~ (!"*/" ~ ANY)* ~ "*/" ) | ("//" ~ (!(NEWLINE) ~ ANY)* ~ N
 
 //A component definition requires at least one element in its template; a `@settings` block may also be included, and any future relevant blocks like `@defaults`
 //The parser will willingly _parse_ multiple @settings/@template blocks per component definition, but the compiler won't presently support them
-pax_component_definition = { SOI ~ (root_tag_pair | settings_block_declaration | block_level_error)+ ~ EOI | empty }
-empty = {SOI}
-block_level_error = { (!(root_tag_pair | settings_block_declaration) ~ ANY)+}
+pax_component_definition = { SOI ~ (root_tag_pair | settings_block_declaration )+ ~ EOI }
 root_tag_pair = { any_tag_pair }
-any_tag_pair = _{statement_control_flow | matched_tag | self_closing_tag | comment | tag_error}
-tag_error = { "<" ~ pascal_identifier ~ (!("<" ~ pascal_identifier | "@settings") ~ ANY)* ~ WHITESPACE* }
+any_tag_pair = _{statement_control_flow | matched_tag | self_closing_tag | comment }
 
 //This duo describes an XML-style open-tag, like <SomeElement id="..."> 
 //and matching close-tag, like </SomeElement>.  Note the use of Pest's stack feature, `PUSH`
 //and `POP`, to match closing & opening tags
-open_tag = {"<" ~ PUSH(pascal_identifier) ~ (attribute_key_value_pair| attribute_key_value_pair_error) * ~ ">"}
-open_tag_error = {"<" ~ PUSH(pascal_identifier) ~ (attribute_key_value_pair| attribute_key_value_pair_error)*}
+open_tag = {"<" ~ PUSH(pascal_identifier) ~ attribute_key_value_pair * ~ ">"}
 closing_tag = {"<" ~ "/" ~ POP ~ ">"}
 
 //Describes a (leaf-node) self-closing element, like <SomeElement />
-self_closing_tag = {"<" ~ pascal_identifier ~ (attribute_key_value_pair | attribute_key_value_pair_error)* ~ "/" ~ ">"}
-
-attribute_key_value_pair_error = { (!(attribute_key_value_pair | "/" | ">" | "<")  ~ ANY)+}
+self_closing_tag = {"<" ~ pascal_identifier ~ attribute_key_value_pair* ~ "/" ~ ">"}
 
 //Describes an XML subtree surrounded by a pair of matching tags, like
 //<SomeElement>...</SomeElement>
-matched_tag = {(open_tag | open_tag_error) ~ inner_nodes ~ closing_tag}
-inner_nodes = { node_inner_content | (any_tag_pair | inner_tag_error)* }
-inner_tag_error = {(!(any_tag_pair| "}" | ("<"~"/")  ) ~ ANY)+}
+matched_tag = {open_tag ~ inner_nodes ~ closing_tag}
+inner_nodes = { node_inner_content | any_tag_pair* }
 
 //Describes an atomic symbolic identifier, like `id`, `Engine`, or `some_thing`
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
@@ -80,10 +73,9 @@ char = {
 /// BEGIN SETTINGS
 //////
 
-settings_block_declaration = {"@" ~ "settings" ~ "{" ~ (settings_event_binding | selector_block | comment | selector_block_error)* ~ "}"}
-selector_block_error = {(!(WHITESPACE | "}") ~ ANY)+ ~ "}"}
+settings_block_declaration = {"@" ~ "settings" ~ "{" ~ (settings_event_binding | selector_block | comment )* ~ "}"}
 selector_block = {selector ~ literal_object ~  silent_comma? }
-literal_object = { pascal_identifier? ~ "{" ~ (settings_key_value_pair | comment)* ~ "}" }
+literal_object = { pascal_identifier? ~ "{" ~ (settings_key_value_pair  | comment)* ~ "}" }
 //Describes a CSS-style selector, used for joining settings to elements
 //Note: only basic `id` and `class` syntax supported for now; could be extended
 //Example: `#some-element`
@@ -185,10 +177,8 @@ literal_color_const = {
 expression_body =   { xo_prefix* ~ xo_primary ~ (xo_infix ~ xo_prefix* ~ xo_primary )* }
 
 expression_wrapped = _{
-    "{" ~ comment? ~ (expression_body| expression_body_error) ~ "}"
+    "{" ~ comment? ~ expression_body ~ "}"
 }
-
-expression_body_error = { ( !(expression_body | "}") ~ ANY) + }
 
 expression_grouped = { "(" ~ expression_body ~ ")" ~ literal_number_unit? }
 
@@ -266,7 +256,8 @@ xo_literal = {literal_color | literal_enum_value | literal_tuple_access | litera
 //objects may recurse into arbitrary expressions for any value -- consider the `key_2` in:
 // `some_prop={ TypedReturn {key_0: 0, key_1: "one", key_2: 1.0 + 1.0} }`
 xo_object = { identifier? ~ "{" ~ xo_object_settings_key_value_pair* ~ "}" }
-xo_object_settings_key_value_pair = { settings_key ~ expression_body ~ silent_comma? }
+
+xo_object_settings_key_value_pair = { settings_key ~ expression_body  ~ silent_comma? }
 
 xo_symbol = { "$"? ~ identifier ~ (("." ~ identifier) | ("[" ~ expression_body ~ "]") )* }
 xo_tuple = { "(" ~ expression_body ~ ("," ~ expression_body)* ~ ")"}

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-language-server"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Warfa Jibril <warfa@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -18,8 +18,8 @@ tokio = { version = "1.32.0", features = ["full"] }
 tower-lsp = "0.20.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0.33"
-pax-compiler = {version = "0.14.7", path="../pax-compiler"}
-pax-lang = {version = "0.14.7", path="../pax-lang"}
+pax-compiler = {version = "0.14.8", path="../pax-compiler"}
+pax-lang = {version = "0.14.8", path="../pax-lang"}
 phf = { version = "0.11.2", features=["macros"] }
 once_cell = "1.18.0"
 lazy_static = "1.4.0"

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -25,3 +25,4 @@ once_cell = "1.18.0"
 lazy_static = "1.4.0"
 ropey = "1.6.0"
 regex = "1.10.1"
+pest = {version = "2.7.10", features = ["std"]}

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-language-server"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Warfa Jibril <warfa@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -18,8 +18,8 @@ tokio = { version = "1.32.0", features = ["full"] }
 tower-lsp = "0.20.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0.33"
-pax-compiler = {version = "0.14.5", path="../pax-compiler"}
-pax-lang = {version = "0.14.5", path="../pax-lang"}
+pax-compiler = {version = "0.14.6", path="../pax-compiler"}
+pax-lang = {version = "0.14.6", path="../pax-lang"}
 phf = { version = "0.11.2", features=["macros"] }
 once_cell = "1.18.0"
 lazy_static = "1.4.0"

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-language-server"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Warfa Jibril <warfa@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -18,8 +18,8 @@ tokio = { version = "1.32.0", features = ["full"] }
 tower-lsp = "0.20.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0.33"
-pax-compiler = {version = "0.14.4", path="../pax-compiler"}
-pax-lang = {version = "0.14.4", path="../pax-lang"}
+pax-compiler = {version = "0.14.5", path="../pax-compiler"}
+pax-lang = {version = "0.14.5", path="../pax-lang"}
 phf = { version = "0.11.2", features=["macros"] }
 once_cell = "1.18.0"
 lazy_static = "1.4.0"

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-language-server"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Warfa Jibril <warfa@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -18,8 +18,8 @@ tokio = { version = "1.32.0", features = ["full"] }
 tower-lsp = "0.20.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0.33"
-pax-compiler = {version = "0.14.6", path="../pax-compiler"}
-pax-lang = {version = "0.14.6", path="../pax-lang"}
+pax-compiler = {version = "0.14.7", path="../pax-compiler"}
+pax-lang = {version = "0.14.7", path="../pax-lang"}
 phf = { version = "0.11.2", features=["macros"] }
 once_cell = "1.18.0"
 lazy_static = "1.4.0"

--- a/pax-language-server/src/index.rs
+++ b/pax-language-server/src/index.rs
@@ -13,9 +13,7 @@ use syn::{Fields, ItemEnum, ItemUse, UseTree};
 
 fn contains_pax_file_macro(attrs: &[Attribute], target_file_path: &str) -> bool {
     // Check for the pax procedural macro
-    let has_pax_macro = attrs
-        .iter()
-        .any(|attr| attr.path.is_ident("pax"));
+    let has_pax_macro = attrs.iter().any(|attr| attr.path.is_ident("pax"));
 
     // Check for the file attribute with a matching file path
     let has_file_attr = attrs.iter().any(|attr| {

--- a/pax-language-server/src/index.rs
+++ b/pax-language-server/src/index.rs
@@ -12,10 +12,12 @@ use syn::{
 use syn::{Fields, ItemEnum, ItemUse, UseTree};
 
 fn contains_pax_file_macro(attrs: &[Attribute], target_file_path: &str) -> bool {
-    let has_pax_derive = attrs
+    // Check for the pax procedural macro
+    let has_pax_macro = attrs
         .iter()
-        .any(|attr| attr.path.is_ident("derive") && attr.tokens.to_string().contains("Pax"));
+        .any(|attr| attr.path.is_ident("pax"));
 
+    // Check for the file attribute with a matching file path
     let has_file_attr = attrs.iter().any(|attr| {
         attr.path.is_ident("file")
             && match attr.parse_meta() {
@@ -31,7 +33,7 @@ fn contains_pax_file_macro(attrs: &[Attribute], target_file_path: &str) -> bool 
             }
     });
 
-    has_pax_derive && has_file_attr
+    has_pax_macro && has_file_attr
 }
 
 pub fn find_rust_file_with_macro<P: AsRef<Path>>(

--- a/pax-language-server/src/lib.rs
+++ b/pax-language-server/src/lib.rs
@@ -6,11 +6,11 @@ use completion::{
     get_struct_static_member_completions,
 };
 use completion::{get_event_completions, get_struct_completion};
-use pest::error::LineColLocation;
 use core::panic;
 use dashmap::DashMap;
 use lsp_types::request::Request;
 use pax_lang::{parse_pax_err, Rule};
+use pest::error::LineColLocation;
 use positional::is_inside_handlers_block;
 use positional::is_inside_selector_block;
 use positional::is_inside_settings_block;
@@ -357,30 +357,26 @@ impl Backend {
             }
             Err(e) => {
                 let range = match e.line_col {
-                    LineColLocation::Pos((l,c)) => {
-                        Range {
-                            start: Position {
-                                line: (l-1) as u32,
-                                character: (c-1) as u32,
-                            },
-                            end: Position {
-                                line: (l-1) as u32,
-                                character: (c-1) as u32,
-                            },
-                        }
+                    LineColLocation::Pos((l, c)) => Range {
+                        start: Position {
+                            line: (l - 1) as u32,
+                            character: (c - 1) as u32,
+                        },
+                        end: Position {
+                            line: (l - 1) as u32,
+                            character: (c - 1) as u32,
+                        },
                     },
-                    LineColLocation::Span((l_s,c_s),(l_e,c_e)) => {
-                        Range {
-                            start: Position {
-                                line: (l_s-1) as u32,
-                                character: (c_s-1) as u32,
-                            },
-                            end: Position {
-                                line: (l_e-1) as u32,
-                                character: (c_e-1) as u32,
-                            },
-                        }
-                    }
+                    LineColLocation::Span((l_s, c_s), (l_e, c_e)) => Range {
+                        start: Position {
+                            line: (l_s - 1) as u32,
+                            character: (c_s - 1) as u32,
+                        },
+                        end: Position {
+                            line: (l_e - 1) as u32,
+                            character: (c_e - 1) as u32,
+                        },
+                    },
                 };
                 vec![Diagnostic {
                     range: range,

--- a/pax-language-server/src/lib.rs
+++ b/pax-language-server/src/lib.rs
@@ -360,24 +360,24 @@ impl Backend {
                     LineColLocation::Pos((l,c)) => {
                         Range {
                             start: Position {
-                                line: l as u32,
-                                character: c as u32,
+                                line: l-1 as u32,
+                                character: c-1 as u32,
                             },
                             end: Position {
-                                line: l as u32,
-                                character: c as u32,
+                                line: l-1 as u32,
+                                character: c-1 as u32,
                             },
                         }
                     },
                     LineColLocation::Span((l_s,c_s),(l_e,c_e)) => {
                         Range {
                             start: Position {
-                                line: l_s as u32,
-                                character: c_s as u32,
+                                line: l_s-1 as u32,
+                                character: c_s-1 as u32,
                             },
                             end: Position {
-                                line: l_e as u32,
-                                character: c_e as u32,
+                                line: l_e-1 as u32,
+                                character: c_e-1 as u32,
                             },
                         }
                     }

--- a/pax-language-server/src/lib.rs
+++ b/pax-language-server/src/lib.rs
@@ -360,24 +360,24 @@ impl Backend {
                     LineColLocation::Pos((l,c)) => {
                         Range {
                             start: Position {
-                                line: l-1 as u32,
-                                character: c-1 as u32,
+                                line: (l-1) as u32,
+                                character: (c-1) as u32,
                             },
                             end: Position {
-                                line: l-1 as u32,
-                                character: c-1 as u32,
+                                line: (l-1) as u32,
+                                character: (c-1) as u32,
                             },
                         }
                     },
                     LineColLocation::Span((l_s,c_s),(l_e,c_e)) => {
                         Range {
                             start: Position {
-                                line: l_s-1 as u32,
-                                character: c_s-1 as u32,
+                                line: (l_s-1) as u32,
+                                character: (c_s-1) as u32,
                             },
                             end: Position {
-                                line: l_e-1 as u32,
-                                character: c_e-1 as u32,
+                                line: (l_e-1) as u32,
+                                character: (c_e-1) as u32,
                             },
                         }
                     }

--- a/pax-language-server/src/positional.rs
+++ b/pax-language-server/src/positional.rs
@@ -103,7 +103,7 @@ pub fn extract_positional_nodes(
             });
             return;
         }
-        Rule::open_tag | Rule::open_tag_error | Rule::tag_error | Rule::self_closing_tag => {
+        Rule::open_tag | Rule::self_closing_tag => {
             if let Some(inner_pair) = inner.find(|p| p.as_rule() == Rule::pascal_identifier) {
                 let identifier = inner_pair.as_str().to_string();
                 nodes.push(PositionalNode {
@@ -235,13 +235,6 @@ pub fn extract_positional_nodes(
                     }),
                 });
             }
-        }
-        Rule::attribute_key_value_pair_error => {
-            nodes.push(PositionalNode {
-                start,
-                end,
-                node_type: NodeType::AttributeKeyValuePairError(),
-            });
         }
         Rule::xo_enum_or_function_call => {
             let inner_pairs = &inner;

--- a/pax-macro/Cargo.toml
+++ b/pax-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-macro"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ proc-macro = true
 syn = {version = "1.0", features=["derive", "extra-traits"]}
 proc-macro2 = "1.0"
 quote = "1.0"
-pax-runtime = {version = "0.14.7", path="../pax-runtime"}
-pax-lang = {version = "0.14.7", path="../pax-lang"}
+pax-runtime = {version = "0.14.8", path="../pax-runtime"}
+pax-lang = {version = "0.14.8", path="../pax-lang"}
 sailfish = "0.6.0"
 serde = { version = "1.0.159", features=["derive"] }
 serde_json = { version = "1.0.95" }

--- a/pax-macro/Cargo.toml
+++ b/pax-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-macro"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ proc-macro = true
 syn = {version = "1.0", features=["derive", "extra-traits"]}
 proc-macro2 = "1.0"
 quote = "1.0"
-pax-runtime = {version = "0.14.4", path="../pax-runtime"}
-pax-lang = {version = "0.14.4", path="../pax-lang"}
+pax-runtime = {version = "0.14.5", path="../pax-runtime"}
+pax-lang = {version = "0.14.5", path="../pax-lang"}
 sailfish = "0.6.0"
 serde = { version = "1.0.159", features=["derive"] }
 serde_json = { version = "1.0.95" }

--- a/pax-macro/Cargo.toml
+++ b/pax-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-macro"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ proc-macro = true
 syn = {version = "1.0", features=["derive", "extra-traits"]}
 proc-macro2 = "1.0"
 quote = "1.0"
-pax-runtime = {version = "0.14.5", path="../pax-runtime"}
-pax-lang = {version = "0.14.5", path="../pax-lang"}
+pax-runtime = {version = "0.14.6", path="../pax-runtime"}
+pax-lang = {version = "0.14.6", path="../pax-lang"}
 sailfish = "0.6.0"
 serde = { version = "1.0.159", features=["derive"] }
 serde_json = { version = "1.0.95" }

--- a/pax-macro/Cargo.toml
+++ b/pax-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-macro"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ proc-macro = true
 syn = {version = "1.0", features=["derive", "extra-traits"]}
 proc-macro2 = "1.0"
 quote = "1.0"
-pax-runtime = {version = "0.14.6", path="../pax-runtime"}
-pax-lang = {version = "0.14.6", path="../pax-lang"}
+pax-runtime = {version = "0.14.7", path="../pax-runtime"}
+pax-lang = {version = "0.14.7", path="../pax-lang"}
 sailfish = "0.6.0"
 serde = { version = "1.0.159", features=["derive"] }
 serde_json = { version = "1.0.95" }

--- a/pax-macro/src/lib.rs
+++ b/pax-macro/src/lib.rs
@@ -66,7 +66,7 @@ fn pax_struct_only_component(
 
         pascal_identifier: pascal_identifier.clone(),
         static_property_definitions,
-        is_custom_interpolatable
+        is_custom_interpolatable,
     }
     .render_once()
     .unwrap()
@@ -277,12 +277,12 @@ fn pax_full_component(
         get_static_property_definitions_from_tokens(&input_parsed.data);
 
     let mut template_dependencies = vec![];
-    let mut error_message : Option<String> = None;
+    let mut error_message: Option<String> = None;
 
     match parsing::parse_pascal_identifiers_from_component_definition_string(&raw_pax) {
         Ok(deps) => {
             template_dependencies = deps;
-        },
+        }
         Err(err) => {
             error_message = Some(err);
         }
@@ -310,7 +310,7 @@ fn pax_full_component(
             template_dependencies,
             reexports_snippet,
             associated_pax_file_path,
-            error_message
+            error_message,
         }),
         pascal_identifier,
         static_property_definitions,

--- a/pax-macro/src/lib.rs
+++ b/pax-macro/src/lib.rs
@@ -66,7 +66,7 @@ fn pax_struct_only_component(
 
         pascal_identifier: pascal_identifier.clone(),
         static_property_definitions,
-        is_custom_interpolatable,
+        is_custom_interpolatable
     }
     .render_once()
     .unwrap()
@@ -276,8 +276,17 @@ fn pax_full_component(
     let static_property_definitions =
         get_static_property_definitions_from_tokens(&input_parsed.data);
 
-    let mut template_dependencies =
-        parsing::parse_pascal_identifiers_from_component_definition_string(&raw_pax);
+    let mut template_dependencies = vec![];
+    let mut error_message : Option<String> = None;
+
+    match parsing::parse_pascal_identifiers_from_component_definition_string(&raw_pax) {
+        Ok(deps) => {
+            template_dependencies = deps;
+        },
+        Err(err) => {
+            error_message = Some(err);
+        }
+    }
 
     // Add BlankComponent to template_dependencies so it's guaranteed to be included in the PaxManifest
     if is_main_component {
@@ -301,6 +310,7 @@ fn pax_full_component(
             template_dependencies,
             reexports_snippet,
             associated_pax_file_path,
+            error_message
         }),
         pascal_identifier,
         static_property_definitions,

--- a/pax-macro/src/parsing.rs
+++ b/pax-macro/src/parsing.rs
@@ -4,9 +4,11 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-pub fn parse_pascal_identifiers_from_component_definition_string(pax: &str) -> Result<Vec<String>, String> {
+pub fn parse_pascal_identifiers_from_component_definition_string(
+    pax: &str,
+) -> Result<Vec<String>, String> {
     let pax_component_definition = parse_pax_str(Rule::pax_component_definition, pax)?;
-   
+
     let pascal_identifiers: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
     pax_component_definition
         .into_inner()

--- a/pax-macro/src/parsing.rs
+++ b/pax-macro/src/parsing.rs
@@ -1,100 +1,13 @@
-use pax_lang::{Pair, Pairs, Parser, PaxParser, Rule};
+use pax_lang::{parse_pax_str, Pair, Pairs, Parser, PaxParser, Rule};
 
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-#[derive(Debug)]
-pub struct ParsingError {
-    pub error_name: String,
-    pub error_message: String,
-    pub matched_string: String,
-    pub start: (usize, usize),
-    pub end: (usize, usize),
-}
-
-/// Extract all errors from a Pax parse result
-pub fn extract_errors(pairs: Pairs<Rule>) -> Vec<ParsingError> {
-    let mut errors = vec![];
-
-    for pair in pairs {
-        let error = match pair.as_rule() {
-            Rule::block_level_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Unexpected template structure encountered.".to_string(),
-            )),
-            Rule::attribute_key_value_pair_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Attribute key-value pair is malformed.".to_string(),
-            )),
-            Rule::inner_tag_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Inner tag doesn't match any expected format.".to_string(),
-            )),
-            Rule::selector_block_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Selector block structure is not well-defined.".to_string(),
-            )),
-            Rule::expression_body_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Expression inside curly braces is not well defined.".to_string(),
-            )),
-            Rule::open_tag_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Open tag is malformed".to_string(),
-            )),
-            Rule::tag_error => Some((
-                format!("{:?}", pair.as_rule()),
-                "Tag structure is unexpected.".to_string(),
-            )),
-            _ => None,
-        };
-        if let Some((error_name, error_message)) = error {
-            let span = pair.as_span();
-            let ((line_start, start_col), (line_end, end_col)) =
-                (pair.line_col(), span.end_pos().line_col());
-            let error = ParsingError {
-                error_name,
-                error_message,
-                matched_string: span.as_str().to_string(),
-                start: (line_start, start_col),
-                end: (line_end, end_col),
-            };
-            errors.push(error);
-        }
-        errors.extend(extract_errors(pair.into_inner()));
-    }
-
-    errors
-}
-
-pub fn parse_pascal_identifiers_from_component_definition_string(pax: &str) -> Vec<String> {
-    let pax_component_definition = PaxParser::parse(Rule::pax_component_definition, pax)
-        .expect(&format!("unsuccessful parse from {}", &pax))
-        .next()
-        .unwrap();
-
-    let errors = extract_errors(pax_component_definition.clone().into_inner());
-    if !errors.is_empty() {
-        let mut error_messages = String::new();
-
-        for error in &errors {
-            let msg = format!(
-                "error: {}\n   --> {}:{}\n    |\n{}  | {}\n    |{}\n\n",
-                error.error_message,
-                error.start.0,
-                error.start.1,
-                error.start.0,
-                error.matched_string,
-                "^".repeat(error.matched_string.len())
-            );
-            error_messages.push_str(&msg);
-        }
-
-        panic!("{}", error_messages);
-    }
-
-    let pascal_identifiers = Rc::new(RefCell::new(HashSet::new()));
+pub fn parse_pascal_identifiers_from_component_definition_string(pax: &str) -> Result<Vec<String>, String> {
+    let pax_component_definition = parse_pax_str(Rule::pax_component_definition, pax)?;
+   
+    let pascal_identifiers: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
     pax_component_definition
         .into_inner()
         .for_each(|pair| match pair.as_rule() {
@@ -106,9 +19,8 @@ pub fn parse_pascal_identifiers_from_component_definition_string(pax: &str) -> V
             }
             _ => {}
         });
-
     let unwrapped_hashmap = Rc::try_unwrap(pascal_identifiers).unwrap().into_inner();
-    unwrapped_hashmap.into_iter().collect()
+    Ok(unwrapped_hashmap.into_iter().collect())
 }
 
 fn recurse_visit_tag_pairs_for_pascal_identifiers(

--- a/pax-macro/src/templating.rs
+++ b/pax-macro/src/templating.rs
@@ -31,6 +31,7 @@ pub struct ArgsFullComponent {
     pub template_dependencies: Vec<String>,
     pub reexports_snippet: String,
     pub associated_pax_file_path: Option<PathBuf>,
+    pub error_message: Option<String>,
 }
 
 #[derive(TemplateOnce)]

--- a/pax-macro/templates/derive_pax.stpl
+++ b/pax-macro/templates/derive_pax.stpl
@@ -69,6 +69,15 @@ impl pax_compiler::parsing::Reflectable for <%= pascal_identifier %> {
     }
 
     fn parse_to_manifest(mut ctx: pax_compiler::parsing::ParsingContext) -> (pax_compiler::parsing::ParsingContext, Vec<pax_manifest::PropertyDefinition>) {
+         <% if args_full_component.as_ref().is_some() { %>
+            <% if args_full_component.as_ref().unwrap().error_message.is_some() { %>
+                //Error message for main component
+                let error_message = "<%= args_full_component.as_ref().unwrap().error_message.as_ref().unwrap() %>";
+                eprintln!("{}", error_message);
+                std::process::exit(1);
+            <% } %>
+        <% } %>
+        
         let self_type_id = <%= pascal_identifier %>::get_type_id();
         let mut property_definitions : Vec<pax_manifest::PropertyDefinition> = vec![];
         let self_import_path = <%= pascal_identifier %>::get_import_path();

--- a/pax-manifest/Cargo.toml
+++ b/pax-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-manifest"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ parsing = ["pax-lang"]
 
 [dependencies]
 serde = { version="1.0.95", features=["derive"]}
-pax-message = {path="../pax-message", version="0.14.5"}
-pax-runtime-api = {path="../pax-runtime-api", version="0.14.5"}
-pax-lang = {version = "0.14.5", path="../pax-lang", optional = true}
+pax-message = {path="../pax-message", version="0.14.6"}
+pax-runtime-api = {path="../pax-runtime-api", version="0.14.6"}
+pax-lang = {version = "0.14.6", path="../pax-lang", optional = true}
 serde_with = { version= "3.6.1", features = ["json"]} 
 log = "0.4.20"

--- a/pax-manifest/Cargo.toml
+++ b/pax-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-manifest"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ parsing = ["pax-lang"]
 
 [dependencies]
 serde = { version="1.0.95", features=["derive"]}
-pax-message = {path="../pax-message", version="0.14.7"}
-pax-runtime-api = {path="../pax-runtime-api", version="0.14.7"}
-pax-lang = {version = "0.14.7", path="../pax-lang", optional = true}
+pax-message = {path="../pax-message", version="0.14.8"}
+pax-runtime-api = {path="../pax-runtime-api", version="0.14.8"}
+pax-lang = {version = "0.14.8", path="../pax-lang", optional = true}
 serde_with = { version= "3.6.1", features = ["json"]} 
 log = "0.4.20"

--- a/pax-manifest/Cargo.toml
+++ b/pax-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-manifest"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ parsing = ["pax-lang"]
 
 [dependencies]
 serde = { version="1.0.95", features=["derive"]}
-pax-message = {path="../pax-message", version="0.14.6"}
-pax-runtime-api = {path="../pax-runtime-api", version="0.14.6"}
-pax-lang = {version = "0.14.6", path="../pax-lang", optional = true}
+pax-message = {path="../pax-message", version="0.14.7"}
+pax-runtime-api = {path="../pax-runtime-api", version="0.14.7"}
+pax-lang = {version = "0.14.7", path="../pax-lang", optional = true}
 serde_with = { version= "3.6.1", features = ["json"]} 
 log = "0.4.20"

--- a/pax-manifest/Cargo.toml
+++ b/pax-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-manifest"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ parsing = ["pax-lang"]
 
 [dependencies]
 serde = { version="1.0.95", features=["derive"]}
-pax-message = {path="../pax-message", version="0.14.4"}
-pax-runtime-api = {path="../pax-runtime-api", version="0.14.4"}
-pax-lang = {version = "0.14.4", path="../pax-lang", optional = true}
+pax-message = {path="../pax-message", version="0.14.5"}
+pax-runtime-api = {path="../pax-runtime-api", version="0.14.5"}
+pax-lang = {version = "0.14.5", path="../pax-lang", optional = true}
 serde_with = { version= "3.6.1", features = ["json"]} 
 log = "0.4.20"

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-message"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-message"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-message"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-message"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime-api"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>", "Samuel Selleck <samuel@pax.dev>"]
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 kurbo = "0.9.0"
 piet = "0.6.0"
 slotmap = "1.0.7"
-pax-message = {version="0.14.4", path="../pax-message"}
+pax-message = {version="0.14.5", path="../pax-message"}
 log = "0.4.20"

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime-api"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>", "Samuel Selleck <samuel@pax.dev>"]
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 kurbo = "0.9.0"
 piet = "0.6.0"
 slotmap = "1.0.7"
-pax-message = {version="0.14.5", path="../pax-message"}
+pax-message = {version="0.14.6", path="../pax-message"}
 log = "0.4.20"

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime-api"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>", "Samuel Selleck <samuel@pax.dev>"]
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 kurbo = "0.9.0"
 piet = "0.6.0"
 slotmap = "1.0.7"
-pax-message = {version="0.14.7", path="../pax-message"}
+pax-message = {version="0.14.8", path="../pax-message"}
 log = "0.4.20"

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime-api"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>", "Warfa Jibril <warfa@pax.dev>", "Samuel Selleck <samuel@pax.dev>"]
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 kurbo = "0.9.0"
 piet = "0.6.0"
 slotmap = "1.0.7"
-pax-message = {version="0.14.6", path="../pax-message"}
+pax-message = {version="0.14.7", path="../pax-message"}
 log = "0.4.20"

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ kurbo = "0.9.0"
 serde = {version="1.0.196", features=["derive"]}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
-pax-message = {path = "../pax-message", version="0.14.7"}
+pax-message = {path = "../pax-message", version="0.14.8"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
-pax-manifest = {version="0.14.7", path = "../pax-manifest"}
-pax-runtime-api = {version="0.14.7", path = "../pax-runtime-api"}
+pax-manifest = {version="0.14.8", path = "../pax-manifest"}
+pax-runtime-api = {version="0.14.8", path = "../pax-runtime-api"}

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ kurbo = "0.9.0"
 serde = {version="1.0.196", features=["derive"]}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
-pax-message = {path = "../pax-message", version="0.14.5"}
+pax-message = {path = "../pax-message", version="0.14.6"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
-pax-manifest = {version="0.14.5", path = "../pax-manifest"}
-pax-runtime-api = {version="0.14.5", path = "../pax-runtime-api"}
+pax-manifest = {version="0.14.6", path = "../pax-manifest"}
+pax-runtime-api = {version="0.14.6", path = "../pax-runtime-api"}

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ kurbo = "0.9.0"
 serde = {version="1.0.196", features=["derive"]}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
-pax-message = {path = "../pax-message", version="0.14.4"}
+pax-message = {path = "../pax-message", version="0.14.5"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
-pax-manifest = {version="0.14.4", path = "../pax-manifest"}
-pax-runtime-api = {version="0.14.4", path = "../pax-runtime-api"}
+pax-manifest = {version="0.14.5", path = "../pax-manifest"}
+pax-runtime-api = {version="0.14.5", path = "../pax-runtime-api"}

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ kurbo = "0.9.0"
 serde = {version="1.0.196", features=["derive"]}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
-pax-message = {path = "../pax-message", version="0.14.6"}
+pax-message = {path = "../pax-message", version="0.14.7"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
-pax-manifest = {version="0.14.6", path = "../pax-manifest"}
-pax-runtime-api = {version="0.14.6", path = "../pax-runtime-api"}
+pax-manifest = {version="0.14.7", path = "../pax-manifest"}
+pax-runtime-api = {version="0.14.7", path = "../pax-runtime-api"}

--- a/pax-std/Cargo.toml
+++ b/pax-std/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "pax-std"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,13 +16,13 @@ primitives_crate = "./pax-std-primitives"
 [dependencies]
 piet = "0.6.0"
 kurbo = "0.9.0"
-pax-engine = {path = "../pax-engine", version="0.14.7"}
-pax-message = {path = "../pax-message", version="0.14.7"}
+pax-engine = {path = "../pax-engine", version="0.14.8"}
+pax-message = {path = "../pax-message", version="0.14.8"}
 lazy_static = "1.4.0"
-pax-compiler = {path="../pax-compiler", optional = true, version="0.14.7"}
+pax-compiler = {path="../pax-compiler", optional = true, version="0.14.8"}
 serde_json = {version="1.0.95", optional = true}
-pax-manifest = {path = "../pax-manifest", version="0.14.7"}
-pax-runtime = {path = "../pax-runtime", version="0.14.7"}
+pax-manifest = {path = "../pax-manifest", version="0.14.8"}
+pax-runtime = {path = "../pax-runtime", version="0.14.8"}
 serde = { version = "1.0.159", features=["derive"]}
 log = "0.4.20"
 

--- a/pax-std/Cargo.toml
+++ b/pax-std/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "pax-std"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,13 +16,13 @@ primitives_crate = "./pax-std-primitives"
 [dependencies]
 piet = "0.6.0"
 kurbo = "0.9.0"
-pax-engine = {path = "../pax-engine", version="0.14.4"}
-pax-message = {path = "../pax-message", version="0.14.4"}
+pax-engine = {path = "../pax-engine", version="0.14.5"}
+pax-message = {path = "../pax-message", version="0.14.5"}
 lazy_static = "1.4.0"
-pax-compiler = {path="../pax-compiler", optional = true, version="0.14.4"}
+pax-compiler = {path="../pax-compiler", optional = true, version="0.14.5"}
 serde_json = {version="1.0.95", optional = true}
-pax-manifest = {path = "../pax-manifest", version="0.14.4"}
-pax-runtime = {path = "../pax-runtime", version="0.14.4"}
+pax-manifest = {path = "../pax-manifest", version="0.14.5"}
+pax-runtime = {path = "../pax-runtime", version="0.14.5"}
 serde = { version = "1.0.159", features=["derive"]}
 log = "0.4.20"
 

--- a/pax-std/Cargo.toml
+++ b/pax-std/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "pax-std"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,13 +16,13 @@ primitives_crate = "./pax-std-primitives"
 [dependencies]
 piet = "0.6.0"
 kurbo = "0.9.0"
-pax-engine = {path = "../pax-engine", version="0.14.5"}
-pax-message = {path = "../pax-message", version="0.14.5"}
+pax-engine = {path = "../pax-engine", version="0.14.6"}
+pax-message = {path = "../pax-message", version="0.14.6"}
 lazy_static = "1.4.0"
-pax-compiler = {path="../pax-compiler", optional = true, version="0.14.5"}
+pax-compiler = {path="../pax-compiler", optional = true, version="0.14.6"}
 serde_json = {version="1.0.95", optional = true}
-pax-manifest = {path = "../pax-manifest", version="0.14.5"}
-pax-runtime = {path = "../pax-runtime", version="0.14.5"}
+pax-manifest = {path = "../pax-manifest", version="0.14.6"}
+pax-runtime = {path = "../pax-runtime", version="0.14.6"}
 serde = { version = "1.0.159", features=["derive"]}
 log = "0.4.20"
 

--- a/pax-std/Cargo.toml
+++ b/pax-std/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "pax-std"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,13 +16,13 @@ primitives_crate = "./pax-std-primitives"
 [dependencies]
 piet = "0.6.0"
 kurbo = "0.9.0"
-pax-engine = {path = "../pax-engine", version="0.14.6"}
-pax-message = {path = "../pax-message", version="0.14.6"}
+pax-engine = {path = "../pax-engine", version="0.14.7"}
+pax-message = {path = "../pax-message", version="0.14.7"}
 lazy_static = "1.4.0"
-pax-compiler = {path="../pax-compiler", optional = true, version="0.14.6"}
+pax-compiler = {path="../pax-compiler", optional = true, version="0.14.7"}
 serde_json = {version="1.0.95", optional = true}
-pax-manifest = {path = "../pax-manifest", version="0.14.6"}
-pax-runtime = {path = "../pax-runtime", version="0.14.6"}
+pax-manifest = {path = "../pax-manifest", version="0.14.7"}
+pax-runtime = {path = "../pax-runtime", version="0.14.7"}
 serde = { version = "1.0.159", features=["derive"]}
 log = "0.4.20"
 

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-std-primitives"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ description = "Primitives crate for Pax's standard library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-runtime = {path = "../../pax-runtime", version="0.14.6"}
-pax-std = {path = "../", version="0.14.6"}
-pax-message = {path = "../../pax-message", version="0.14.6" }
+pax-runtime = {path = "../../pax-runtime", version="0.14.7"}
+pax-std = {path = "../", version="0.14.7"}
+pax-message = {path = "../../pax-message", version="0.14.7" }
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-std-primitives"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ description = "Primitives crate for Pax's standard library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-runtime = {path = "../../pax-runtime", version="0.14.4"}
-pax-std = {path = "../", version="0.14.4"}
-pax-message = {path = "../../pax-message", version="0.14.4" }
+pax-runtime = {path = "../../pax-runtime", version="0.14.5"}
+pax-std = {path = "../", version="0.14.5"}
+pax-message = {path = "../../pax-message", version="0.14.5" }
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-std-primitives"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ description = "Primitives crate for Pax's standard library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-runtime = {path = "../../pax-runtime", version="0.14.5"}
-pax-std = {path = "../", version="0.14.5"}
-pax-message = {path = "../../pax-message", version="0.14.5" }
+pax-runtime = {path = "../../pax-runtime", version="0.14.6"}
+pax-std = {path = "../", version="0.14.6"}
+pax-message = {path = "../../pax-message", version="0.14.6" }
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-std-primitives"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ description = "Primitives crate for Pax's standard library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-runtime = {path = "../../pax-runtime", version="0.14.7"}
-pax-std = {path = "../", version="0.14.7"}
-pax-message = {path = "../../pax-message", version="0.14.7" }
+pax-runtime = {path = "../../pax-runtime", version="0.14.8"}
+pax-std = {path = "../", version="0.14.8"}
+pax-message = {path = "../../pax-message", version="0.14.8" }
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"


### PR DESCRIPTION
- Refactor error handling through pax-lang
- Improve pax-macro to pass parsing errors into the template so errors aren't at macro-time 
- Refactor pax-compiler, and pax-language-server to use new errors
- fixed space-game since anchors were removed erroneously
++ release
