### PR TITLE
Bug fixes and changes needed during designer migration

### DIFF
--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -22,7 +22,7 @@ use pax_runtime::{ExpressionTable, PaxEngine, Renderer};
 //in order to be visible to Swift
 pub use pax_message::*;
 use pax_runtime::api::{
-    Click, ModifierKey, MouseButton, MouseEventArgs, Platform, RenderContext, OS,
+    borrow, Click, ModifierKey, MouseButton, MouseEventArgs, Platform, RenderContext, OS,
 };
 
 /// Container data structure for PaxEngine, aggregated to support passing across C bridge
@@ -99,7 +99,6 @@ pub extern "C" fn pax_interrupt(
         NativeInterrupt::Click(args) => {
             let prospective_hit = engine
                 .runtime_context
-                .borrow()
                 .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
             match prospective_hit {
                 Some(topmost_node) => {
@@ -118,7 +117,7 @@ pub extern "C" fn pax_interrupt(
                     };
                     topmost_node.dispatch_click(
                         args_click,
-                        engine.runtime_context.borrow().globals(),
+                        &engine.runtime_context.globals(),
                         &engine.runtime_context,
                     );
                 }

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -21,6 +21,7 @@ piet-web = "0.6.0"
 pax-runtime = { path = "../pax-runtime", version="0.14.9" }
 pax-cartridge = {path="../pax-cartridge", version="0.14.9"}
 pax-message = {path = "../pax-message", version="0.14.9"}
+pax-runtime-api = { path = "../pax-runtime-api", version="0.14.9" }
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
 console_log = "1.0.0"

--- a/pax-chassis-web/interface/src/utils/helpers.ts
+++ b/pax-chassis-web/interface/src/utils/helpers.ts
@@ -1,28 +1,13 @@
 export async function readImageToByteBuffer(imagePath: string): Promise<{ pixels: Uint8ClampedArray, width: number, height: number }> {
     const response = await fetch(imagePath);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch image at ${imagePath}, status: ${response.status}`);
-    }
-
     const blob = await response.blob();
-
-    let img;
-    try {
-        img = await createImageBitmap(blob);
-    } catch (error) {
-        throw new Error(`Failed to decode image at path "${imagePath}"`);
-    }    
-    const canvas = new OffscreenCanvas(img.width, img.height);
+    const img = await createImageBitmap(blob);
+    const canvas = new OffscreenCanvas(img.width+1000, img.height);
     const ctx = canvas.getContext('2d');
-
-    if (ctx) {
-        ctx.drawImage(img, 0, 0, img.width, img.height);
-        const imageData = ctx.getImageData(0, 0, img.width, img.height);
-        const pixels = imageData.data;
-        return { pixels, width: img.width, height: img.height };
-    } else {
-        throw new Error("Failed to get 2D context from OffscreenCanvas.");
-    }
+    ctx!.drawImage(img, 0, 0, img.width, img.height);
+    const imageData = ctx!.getImageData(0, 0, img.width, img.height);
+    let pixels = imageData.data;
+    return { pixels, width: img.width, height: img.height };
 }
 
 //Required due to Safari bug, unable to clip DOM elements to SVG=>`transform: matrix(...)` elements; see https://bugs.webkit.org/show_bug.cgi?id=126207

--- a/pax-chassis-web/interface/src/utils/helpers.ts
+++ b/pax-chassis-web/interface/src/utils/helpers.ts
@@ -1,13 +1,28 @@
 export async function readImageToByteBuffer(imagePath: string): Promise<{ pixels: Uint8ClampedArray, width: number, height: number }> {
     const response = await fetch(imagePath);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch image at ${imagePath}, status: ${response.status}`);
+    }
+
     const blob = await response.blob();
-    const img = await createImageBitmap(blob);
-    const canvas = new OffscreenCanvas(img.width+1000, img.height);
+
+    let img;
+    try {
+        img = await createImageBitmap(blob);
+    } catch (error) {
+        throw new Error(`Failed to decode image at path "${imagePath}"`);
+    }    
+    const canvas = new OffscreenCanvas(img.width, img.height);
     const ctx = canvas.getContext('2d');
-    ctx!.drawImage(img, 0, 0, img.width, img.height);
-    const imageData = ctx!.getImageData(0, 0, img.width, img.height);
-    let pixels = imageData.data;
-    return { pixels, width: img.width, height: img.height };
+
+    if (ctx) {
+        ctx.drawImage(img, 0, 0, img.width, img.height);
+        const imageData = ctx.getImageData(0, 0, img.width, img.height);
+        const pixels = imageData.data;
+        return { pixels, width: img.width, height: img.height };
+    } else {
+        throw new Error("Failed to get 2D context from OffscreenCanvas.");
+    }
 }
 
 //Required due to Safari bug, unable to clip DOM elements to SVG=>`transform: matrix(...)` elements; see https://bugs.webkit.org/show_bug.cgi?id=126207

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -215,6 +215,7 @@ impl PaxChassisWeb {
                 let node = engine
                     .get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id))
                     .expect("text node exists in engine");
+                borrow!(node.instance_node).handle_text_change(&node, args.text.clone());
                 node.dispatch_text_input(
                     TextInput { text: args.text },
                     &globals,

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -597,7 +597,7 @@ impl PaxChassisWeb {
     pub fn update_userland_component(&mut self) {
         let current_manifest_version = borrow!(self.designtime_manager).get_manifest_version();
         let reload_type = borrow!(self.designtime_manager).get_reload_queue();
-        if current_manifest_version != self.last_manifest_version_rendered {
+        if current_manifest_version.get() != self.last_manifest_version_rendered {
             if let Some(reload_type) = reload_type {
                 match reload_type {
                     ReloadType::FullEdit => {
@@ -631,7 +631,7 @@ impl PaxChassisWeb {
                     }
                 }
             }
-            self.last_manifest_version_rendered = current_manifest_version;
+            self.last_manifest_version_rendered = current_manifest_version.get();
         }
     }
 
@@ -645,8 +645,7 @@ impl PaxChassisWeb {
     #[cfg(feature = "designtime")]
     pub fn designtime_tick(&mut self) {
         self.handle_recv_designtime();
-        // TODOdag re-connect designtime updates
-        // self.update_userland_component();
+        self.update_userland_component();
     }
 
     pub fn tick(&mut self) -> MemorySlice {

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -656,7 +656,8 @@ impl PaxChassisWeb {
     #[cfg(feature = "designtime")]
     pub fn designtime_tick(&mut self) {
         self.handle_recv_designtime();
-        self.update_userland_component();
+        // TODOdag re-connect designtime updates
+        // self.update_userland_component();
     }
 
     pub fn tick(&mut self) -> MemorySlice {

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -1486,12 +1486,12 @@ impl Reflectable for Stroke {
                 },
             );
         }
-        let color_type_id = Size::get_type_id();
-        if !ctx.type_table.contains_key(&color_type_id) {
+        let size_type_id = Size::get_type_id();
+        if !ctx.type_table.contains_key(&size_type_id) {
             ctx.type_table.insert(
-                color_type_id.clone(),
+                size_type_id.clone(),
                 TypeDefinition {
-                    type_id: color_type_id,
+                    type_id: size_type_id,
                     inner_iterable_type_id: None,
                     property_definitions: vec![],
                 },

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -1475,6 +1475,28 @@ impl Reflectable for Stroke {
         if !ctx.type_table.contains_key(&type_id) {
             ctx.type_table.insert(type_id, td);
         }
+        let color_type_id = Color::get_type_id();
+        if !ctx.type_table.contains_key(&color_type_id) {
+            ctx.type_table.insert(
+                color_type_id.clone(),
+                TypeDefinition {
+                    type_id: color_type_id,
+                    inner_iterable_type_id: None,
+                    property_definitions: vec![],
+                },
+            );
+        }
+        let color_type_id = Size::get_type_id();
+        if !ctx.type_table.contains_key(&color_type_id) {
+            ctx.type_table.insert(
+                color_type_id.clone(),
+                TypeDefinition {
+                    type_id: color_type_id,
+                    inner_iterable_type_id: None,
+                    property_definitions: vec![],
+                },
+            );
+        }
 
         (ctx, vec![])
     }

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -147,7 +147,8 @@ pub trait ComponentFactory {
                     "{{common_property.name}}" => {
                         let resolved_property: Property<{{common_property.property_type._type_id}}> = match value.clone() {
                             ValueDefinition::LiteralValue(lv) => {
-                                let val = <{{common_property.property_type._type_id}}>::from_pax_any(from_pax_try_coerce::<{{common_property.property_type._type_id}}>(&lv.raw_value).unwrap()).unwrap();
+                                let val = from_pax_try_coerce::<{{common_property.property_type._type_id}}>(&lv.raw_value)
+                                    .map_err(|e| format!("failed to read {}: {}", &lv.raw_value, e)).unwrap();
                                 Property::new_with_name(val, &lv.raw_value)
                             },
                             ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token,info) =>
@@ -166,15 +167,7 @@ pub trait ComponentFactory {
                                     Property::computed_with_name(move || {
                                         let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
                                         let coerced = new_value_wrapped.try_coerce::<{{common_property.property_type._type_id}}>().unwrap();
-                                        if let Ok(downcast_value) = <{{common_property.property_type._type_id}}>::from_pax_any(coerced) {
-                                            downcast_value
-                                        } else {
-                                            panic!(
-                                                "property has an unexpected type for vtable id {}",
-                                                info.vtable_id
-                                            );
-                                        }
-                                    
+                                        coerced
                                     }, &dependents, &token.raw_value)
                                 } else {
                                     unreachable!("No info for expression")
@@ -393,14 +386,7 @@ impl DefinitionToInstanceTraverser {
                         properties.boolean_expression =  Property::computed_with_name(move || {
                             let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
                             let coerced = new_value_wrapped.try_coerce::<bool>().unwrap();
-                            if let Ok(downcast_value) = bool::from_pax_any(coerced) {
-                                downcast_value
-                            } else {
-                                panic!(
-                                    "property has an unexpected type for vtable id {}",
-                                    vtable_id
-                                );
-                            }
+                            coerced
                         }, &dependencies, "conditional (if) expr");
                         properties.to_pax_any()
                     })));
@@ -442,14 +428,7 @@ impl DefinitionToInstanceTraverser {
                         properties.index = Property::computed_with_name(move || {
                             let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
                             let coerced = new_value_wrapped.try_coerce::<Numeric>().unwrap();
-                            if let Ok(downcast_value) = Numeric::from_pax_any(coerced) {
-                                downcast_value
-                            } else {
-                                panic!(
-                                    "property has an unexpected type for vtable id {}",
-                                    vtable_id
-                                );
-                            }
+                            coerced
                         }, &dependencies, "slot index");
                         properties.to_pax_any()
                     })));
@@ -501,14 +480,7 @@ impl DefinitionToInstanceTraverser {
                                     Property::computed_with_name(move || {
                                         let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
                                         let coerced = new_value_wrapped.try_coerce::<Vec<Rc<RefCell<PaxAny>>>>().unwrap();
-                                        if let Ok(downcast_value) = <Vec<Rc<RefCell<PaxAny>>>>::from_pax_any(coerced) {
-                                            downcast_value
-                                        } else {
-                                            panic!(
-                                                "property has an unexpected type for vtable id {}",
-                                                vtable_id
-                                            );
-                                        }
+                                        coerced
                                     }, &dependencies, "repeat source vec")
                                     ) 
                             } else {
@@ -523,14 +495,7 @@ impl DefinitionToInstanceTraverser {
                                     Property::computed_with_name(move || {
                                         let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
                                         let coerced = new_value_wrapped.try_coerce::<std::ops::Range::<isize>>().unwrap();
-                                        if let Ok(downcast_value) = <std::ops::Range::<isize>>::from_pax_any(coerced) {
-                                            downcast_value
-                                        } else {
-                                            panic!(
-                                                "property has an unexpected type for vtable id {}",
-                                                vtable_id
-                                            );
-                                        }
+                                        coerced
                                     }, &dependencies, "repeat source range")
                                 )
                             } else {

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -12,6 +12,7 @@ use pax_manifest::ControlFlowRepeatPredicateDefinition::ElemId;
 use pax_runtime_api::pax_value::PaxValue;
 use pax_runtime_api::pax_value::PaxAny;
 use pax_runtime_api::pax_value::ToFromPaxAny;
+use pax_runtime_api::{borrow, borrow_mut};
 use pax_runtime::api::pax_value::ToFromPaxValue;
 
 const INITAL_MANIFEST: &str = include_str!("../initial-manifest.json");
@@ -21,6 +22,7 @@ const INITAL_MANIFEST: &str = include_str!("../initial-manifest.json");
 use {{ import }};
 {% endfor %}
 
+use_RefCell!();
 
 pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionContext) -> PaxAny>> {
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext) -> PaxAny>> = HashMap::new();
@@ -39,7 +41,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
                 } else {
                     panic!("{{ invocation.escaped_identifier }} didn't have an {{ invocation.stack_offset }}th stackframe");
                 };
-                let mut borrowed = &mut *(*properties).borrow_mut();
+                let mut borrowed = &mut *borrow_mut!(*properties);
                 {% if invocation.property_flags.is_binding_repeat_elem %}
                     // binding repeat elem
                     if let Ok(unwrapped_repeat_item) = RepeatItem::ref_from_pax_any(&*borrowed) {
@@ -48,7 +50,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
 
                         {% if invocation.is_numeric %}
                             //iterable numeric as `elem`
-                            let elem_borrowed = elem.borrow();
+                            let elem_borrowed = borrow!(elem);
                             if let Ok(unwrapped) = <{{invocation.fully_qualified_iterable_type}}>::ref_from_pax_any(&*elem_borrowed) {
                                 *unwrapped
                             } else {
@@ -57,7 +59,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
                         {% elif invocation.is_string %}
                             //string as `elem`
 
-                            let elem_borrowed = elem.borrow();
+                            let elem_borrowed = borrow!(elem);
                             if let Ok(unwrapped) = <{{invocation.fully_qualified_iterable_type}}>::ref_from_pax_any(&*elem_borrowed) {
                                 StringBox::from(unwrapped)
                             } else {
@@ -69,7 +71,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
                             elem.clone()
                         {% else %}
                             //iterable complex type
-                            let mut elem_borrowed = &mut *elem.borrow_mut();
+                            let mut elem_borrowed = &mut *borrow_mut!(elem);
                             if let Ok(dc) = <{{invocation.fully_qualified_iterable_type}}>::mut_from_pax_any(elem_borrowed) {
                                 dc.clone()
                             } else {unreachable!()}
@@ -265,7 +267,7 @@ impl DefinitionToInstanceTraverser {
 
     #[cfg(feature = "designtime")]
     pub fn get_manifest(&self) ->  Ref<PaxManifest> {
-        Ref::map(self.designtime_manager.borrow(), |manager| {
+        Ref::map(borrow!(self.designtime_manager), |manager| {
             manager.get_manifest()
         })
     }

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -385,7 +385,7 @@ impl DefinitionToInstanceTraverser {
 
                         properties.boolean_expression =  Property::computed_with_name(move || {
                             let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
-                            let coerced = new_value_wrapped.try_coerce::<bool>().unwrap();
+                            let coerced = new_value_wrapped.try_coerce::<bool>().map_err(|e| format!("expr with vtable_id {} failed: {}", vtable_id, e)).unwrap();
                             coerced
                         }, &dependencies, "conditional (if) expr");
                         properties.to_pax_any()

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -58,7 +58,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
             {% for handler in component.handlers %}
             "{{handler.name}}" => {
                 |properties, ctx, args|{
-                    let properties = &mut *properties.as_ref().borrow_mut();
+                    let properties = &mut *borrow_mut!(properties.as_ref());
                     if let Ok(mut properties) = <{{component.pascal_identifier}}>::mut_from_pax_any(properties) {
                         // downcast args to handler.type
                         {% if handler.args_type %}
@@ -97,7 +97,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
 
     fn add_inline_handlers(&self, handlers: Vec<(String, String)>, handler_registry: Rc<RefCell<HandlerRegistry>>) -> Rc<RefCell<HandlerRegistry>> {
         {
-            let mut handler_registry_mut = handler_registry.borrow_mut();
+            let mut handler_registry_mut = borrow_mut!(handler_registry);
             for (event, fn_name) in &handlers {
                 let handler_vec = handler_registry_mut.handlers.entry(event.clone()).or_insert(Vec::new());
                 handler_vec.push(Handler::new_inline_handler(self.build_handler(&fn_name)));
@@ -116,7 +116,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
 
     fn get_properties_scope_factory(&self) -> Box<dyn Fn(Rc<RefCell<PaxAny>>) -> HashMap<String, UntypedProperty>>  {
         Box::new(|props| {
-            let properties = &mut *props.as_ref().borrow_mut();
+            let properties = &mut *borrow_mut!(props.as_ref());
             if let Ok(properties) = <{{component.pascal_identifier}}>::mut_from_pax_any(properties) {
                 let mut scope = HashMap::new();
                 {% for prop in component.properties %}

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -16,7 +16,8 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                 properties.{{property.name}}.replace_with(
                     match vd.clone() {
                         ValueDefinition::LiteralValue(lv) => {
-                            let val = <{{property.property_type.type_id._type_id}}>::from_pax_any(from_pax_try_coerce::<{{property.property_type.type_id._type_id}}>(&lv.raw_value).unwrap()).unwrap();
+                                let val = from_pax_try_coerce::<{{property.property_type.type_id._type_id}}>(&lv.raw_value)
+                                    .map_err(|e| format!("failed to read {}: {}", &lv.raw_value, e)).unwrap();
                             Property::new_with_name(val, &lv.raw_value)
                         },
                         ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token,info) =>
@@ -35,16 +36,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                                 Property::computed_with_name(move || {
                                     let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
                                     let coerced = new_value_wrapped.try_coerce::<{{property.property_type.type_id._type_id}}>().unwrap();
-                                    if let Ok(downcast_value) = <{{property.property_type.type_id._type_id}}>::from_pax_any(coerced) {
-                                        downcast_value
-                                    } else {
-                                        panic!(
-                                            "property has an unexpected type for vtable id {}. expected: {}",
-                                            info.vtable_id,
-                                            std::any::type_name::<{{property.property_type.type_id._type_id}}>(),
-                                       );
-                                    }
-                                
+                                    coerced
                                 }, &dependents, &token.raw_value)
                             } else {
                                 unreachable!("No info for expression")
@@ -160,7 +152,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                             {% if prop.flags.is_property_wrapped %}
                                 match vd {
                                     ValueDefinition::LiteralValue(lv) => {
-                                        let val = <{{prop.type_id._type_id}}>::from_pax_any(from_pax_try_coerce::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap()).unwrap();
+                                        let val = from_pax_try_coerce::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap();
                                         Property::new_with_name(val, &lv.raw_value)
                                     },
                                     ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token, info ) =>
@@ -180,15 +172,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                             Property::computed_with_name(move || {
                                                 let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, cloned_info.vtable_id);
                                                 let coerced = new_value_wrapped.try_coerce::<{{prop.type_id._type_id}}>().unwrap();
-                                                if let Ok(downcast_value) = <{{prop.type_id._type_id}}>::from_pax_any(coerced) {
-                                                    downcast_value
-                                                } else {
-                                                    panic!(
-                                                        "property has an unexpected type for vtable id {}",
-                                                        cloned_info.vtable_id
-                                                    );
-                                                }
-                                            
+                                                coerced
                                             }, &dependents, &token.raw_value)
                                         } else {
                                             unreachable!("No info for expression")
@@ -202,7 +186,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                             {% else %}
                                 match vd {
                                     ValueDefinition::LiteralValue(lv) => {
-                                        <{{prop.type_id._type_id}}>::from_pax_any(from_pax_try_coerce::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap()).unwrap()
+                                        from_pax_try_coerce::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap()
                                     },
                                     ValueDefinition::Block(block) => {
                                         {{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(args, stack_frame.clone(), table.clone())

--- a/pax-manifest/src/deserializer/mod.rs
+++ b/pax-manifest/src/deserializer/mod.rs
@@ -40,7 +40,7 @@ thread_local! {
 /// type if able, or returns an error
 pub fn from_pax_try_coerce<T: ToFromPaxAny + CoercionRules + Clone + 'static>(
     str: &str,
-) -> std::result::Result<PaxAny, String>
+) -> std::result::Result<T, String>
 where
     T: DeserializeOwned,
 {
@@ -244,10 +244,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                     Rule::string => {
                         let string_within_quotes =
                             inner_pair.into_inner().next().unwrap().as_str().to_string();
-                        visitor.visit_map(PaxObject::new(
-                            Some(STRING_BOX.to_string()),
-                            vec![("string".to_string(), string_within_quotes)],
-                        ))
+                        visitor.visit_string(string_within_quotes)
                     }
                     Rule::literal_tuple => {
                         let pairs = inner_pair.into_inner();

--- a/pax-manifest/src/deserializer/tests.rs
+++ b/pax-manifest/src/deserializer/tests.rs
@@ -2,7 +2,7 @@
 
 use pax_runtime_api::{
     pax_value::{CoercionRules, ToFromPaxAny},
-    Color, ImplToFromPaxAny, Numeric, Rotation, Size, StringBox,
+    Color, ImplToFromPaxAny, Numeric, Rotation, Size,
 };
 use serde::Deserialize;
 
@@ -49,27 +49,19 @@ fn test_radians() {
 }
 
 #[test]
-fn test_string_box() {
-    let string_box_pax = "\"hello\"".to_string();
-    let expected = StringBox {
-        string: "hello".to_string(),
-    };
-    let v = StringBox::from_pax_any(from_pax::<StringBox>(&string_box_pax).unwrap()).unwrap();
+fn test_string() {
+    let string_pax = "\"hello\"".to_string();
+    let expected = String::from("hello");
+    let v = String::from_pax_any(from_pax::<String>(&string_pax).unwrap()).unwrap();
     assert_eq!(expected, v);
 }
 
 #[test]
 fn test_tuple() {
     let tuple_pax = "(\"hello\", 10)".to_string();
-    let expected = (
-        StringBox {
-            string: "hello".to_string(),
-        },
-        Numeric::I64(10),
-    );
-    let v =
-        <(StringBox, Numeric)>::from_pax_any(from_pax::<(StringBox, Numeric)>(&tuple_pax).unwrap())
-            .unwrap();
+    let expected = (String::from("hello"), Numeric::I64(10));
+    let v = <(String, Numeric)>::from_pax_any(from_pax::<(String, Numeric)>(&tuple_pax).unwrap())
+        .unwrap();
     assert_eq!(expected, v);
 }
 

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -6,6 +6,7 @@ use std::{cmp::Ordering, hash::Hash};
 
 use constants::{TYPE_ID_COMMENT, TYPE_ID_IF, TYPE_ID_REPEAT, TYPE_ID_SLOT};
 use pax_message::serde::{Deserialize, Serialize};
+pub use pax_runtime_api;
 use pax_runtime_api::{ImplToFromPaxAny, Interpolatable};
 
 #[cfg(feature = "parsing")]

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -1881,7 +1881,7 @@ pub struct HostCrateInfo {
 //Effectively our `Prelude` types
 pub const IMPORTS_BUILTINS: &[&str] = &[
     "std::any::Any",
-    "std::cell::RefCell",
+    "pax_runtime::api::{use_RefCell}",
     "std::collections::HashMap",
     "std::collections::VecDeque",
     "std::ops::Deref",

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -19,3 +19,4 @@ piet = "0.6.0"
 slotmap = "1.0.7"
 pax-message = {version="0.14.9", path="../pax-message"}
 log = "0.4.20"
+cfg-if = "1.0.0"

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -8,14 +8,15 @@ use pax_value::PaxAny;
 pub use pax_value::{ImplToFromPaxAny, PaxValue, ToFromPaxValue};
 use piet::{PaintBrush, UnitPoint};
 use properties::UntypedProperty;
+pub mod refcell_debug;
+pub use refcell_debug::*;
 
 #[cfg(feature = "designtime")]
 use {
     crate::math::Point2, crate::node_interface::NodeInterface, pax_designtime::DesigntimeManager,
-    std::cell::RefCell,
 };
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::rc::{Rc, Weak};
 
 pub mod constants;
@@ -738,7 +739,6 @@ impl<T: 'static> ImplToFromPaxAny for Rc<T> {}
 impl<T: Clone + 'static> ImplToFromPaxAny for Weak<T> {}
 impl<T: Clone + 'static> ImplToFromPaxAny for Option<T> {}
 impl<T: Clone + 'static> ImplToFromPaxAny for Vec<T> {}
-impl<T: Clone + 'static> ImplToFromPaxAny for RefCell<T> {}
 
 impl<T1: Clone + 'static, T2: Clone + 'static> ImplToFromPaxAny for (T1, T2) {}
 
@@ -763,7 +763,6 @@ impl Interpolatable for () {}
 impl<T: ?Sized + Clone> Interpolatable for HashSet<T> {}
 impl<T: ?Sized> Interpolatable for Rc<T> {}
 impl<T: Interpolatable> Interpolatable for Weak<T> {}
-impl<T: Interpolatable> Interpolatable for RefCell<T> {}
 impl<T1: Interpolatable, T2: Interpolatable> Interpolatable for (T1, T2) {}
 
 impl<I: Interpolatable> Interpolatable for Vec<I> {

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::{Add, Deref, Mul, Neg, Sub};
 
 use crate::math::Space;
@@ -758,10 +758,10 @@ impl<I: Interpolatable> Interpolatable for std::ops::Range<I> {
         self.start.interpolate(&_other.start, _t)..self.end.interpolate(&_other.end, _t)
     }
 }
-impl Interpolatable for Rc<RefCell<PaxAny>> {}
 impl Interpolatable for () {}
 
-impl<T: Interpolatable> Interpolatable for Rc<T> {}
+impl<T: ?Sized + Clone> Interpolatable for HashSet<T> {}
+impl<T: ?Sized> Interpolatable for Rc<T> {}
 impl<T: Interpolatable> Interpolatable for Weak<T> {}
 impl<T: Interpolatable> Interpolatable for RefCell<T> {}
 impl<T1: Interpolatable, T2: Interpolatable> Interpolatable for (T1, T2) {}

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -1477,15 +1477,15 @@ impl Add for Rotation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
 pub struct Stroke {
-    pub color: Color,
-    pub width: Size,
+    pub color: Property<Color>,
+    pub width: Property<Size>,
 }
 
 impl Default for Stroke {
     fn default() -> Self {
         Self {
             color: Default::default(),
-            width: Size::Pixels(Numeric::F64(0.0)),
+            width: Property::new(Size::Pixels(Numeric::F64(0.0))),
         }
     }
 }

--- a/pax-runtime-api/src/math/point.rs
+++ b/pax-runtime-api/src/math/point.rs
@@ -3,6 +3,8 @@ use std::{
     ops::{Add, Sub},
 };
 
+use crate::Interpolatable;
+
 use super::{vector::Vector2, Generic, Space};
 
 pub struct Point2<W = Generic> {
@@ -96,4 +98,8 @@ impl<W: Space> Sub<Vector2<W>> for Point2<W> {
     fn sub(self, rhs: Vector2<W>) -> Self::Output {
         Self::Output::new(self.x - rhs.x, self.y - rhs.y)
     }
+}
+
+impl<W: Space> Interpolatable for Point2<W> {
+    //TODO impl
 }

--- a/pax-runtime-api/src/pax_value/coercion_impls.rs
+++ b/pax-runtime-api/src/pax_value/coercion_impls.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     impl_default_coercion_rule, Color, Fill, ImplToFromPaxAny, Numeric, PaxValue, Percent,
-    Rotation, Size, StringBox, Stroke, Transform2D,
+    Property, Rotation, Size, StringBox, Stroke, Transform2D,
 };
 
 // Default coersion rules:
@@ -56,8 +56,8 @@ impl CoercionRules for Stroke {
     fn try_coerce(pax_value: PaxValue) -> Result<Self, String> {
         Ok(match pax_value {
             PaxValue::Color(color) => Stroke {
-                color,
-                width: Size::Pixels(1.into()),
+                color: Property::new(color),
+                width: Property::new(Size::Pixels(1.into())),
             },
             PaxValue::Stroke(stroke) => stroke,
             _ => return Err(format!("{:?} can't be coerced into a Stroke", pax_value)),

--- a/pax-runtime-api/src/pax_value/mod.rs
+++ b/pax-runtime-api/src/pax_value/mod.rs
@@ -58,16 +58,13 @@ impl PaxAny {
     /// Try to co coerce the inner type to type T. For the any type, just make
     /// sure the stored any value is of type T. For a PaxValue, try to coerce it
     /// into the expected type
-    pub fn try_coerce<T: ToFromPaxAny + CoercionRules + 'static>(self) -> Result<Self, String> {
+    pub fn try_coerce<T: ToFromPaxAny + CoercionRules + 'static>(self) -> Result<T, String> {
         let res = match self {
-            PaxAny::Builtin(pax_type) => T::try_coerce(pax_type).map(|v| v.to_pax_any()),
-            PaxAny::Any(any) => {
-                if any.as_ref().type_id() == TypeId::of::<T>() {
-                    Ok(PaxAny::Any(any))
-                } else {
-                    Err("tried to coerce PaxAny into non-underlying type".to_string())
-                }
-            }
+            PaxAny::Builtin(pax_type) => T::try_coerce(pax_type),
+            PaxAny::Any(any) => any
+                .downcast()
+                .map(|v| *v)
+                .map_err(|_| "tried to coerce PaxAny into non-underlying type".to_string()),
         };
         res
     }

--- a/pax-runtime-api/src/pax_value/mod.rs
+++ b/pax-runtime-api/src/pax_value/mod.rs
@@ -61,10 +61,12 @@ impl PaxAny {
     pub fn try_coerce<T: ToFromPaxAny + CoercionRules + 'static>(self) -> Result<T, String> {
         let res = match self {
             PaxAny::Builtin(pax_type) => T::try_coerce(pax_type),
-            PaxAny::Any(any) => any
-                .downcast()
-                .map(|v| *v)
-                .map_err(|_| "tried to coerce PaxAny into non-underlying type".to_string()),
+            PaxAny::Any(any) => any.downcast().map(|v| *v).map_err(|_| {
+                format!(
+                    "tried to coerce PaxAny into {} which wasn't the underlying type",
+                    std::any::type_name::<T>()
+                )
+            }),
         };
         res
     }

--- a/pax-runtime-api/src/pax_value/numeric.rs
+++ b/pax-runtime-api/src/pax_value/numeric.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::Interpolatable;
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
-#[derive(Debug, Copy, PartialEq)]
+#[derive(Debug, Copy)]
 pub enum Numeric {
     I8(i8),
     I16(i16),
@@ -17,6 +17,15 @@ pub enum Numeric {
     F32(f32),
     ISize(isize),
     USize(usize),
+}
+
+impl PartialEq for Numeric {
+    fn eq(&self, rhs: &Self) -> bool {
+        match (self.is_float(), rhs.is_float()) {
+            (false, false) => self.to_int() == rhs.to_int(),
+            _ => (self.to_float() - rhs.to_float()) < 1e-6,
+        }
+    }
 }
 
 impl Default for Numeric {

--- a/pax-runtime-api/src/properties/mod.rs
+++ b/pax-runtime-api/src/properties/mod.rs
@@ -126,6 +126,23 @@ impl<T: PropertyValue> Property<T> {
         PROPERTY_TABLE.with(|t| t.set_value(self.untyped.id, val));
     }
 
+    // Get access to a mutable reference to the inner value T.
+    // Always updates dependents of this property, no matter
+    // if the value changed or not
+    pub fn update(&self, f: impl FnOnce(&mut T)) {
+        // This is a temporary impl of the update method.
+        // (very bad perf comparatively, but very safe).
+        let mut val = self.get();
+        f(&mut val);
+        self.set(val);
+    }
+
+    // Get access to a reference to the inner value T.
+    pub fn read<V>(&self, f: impl FnOnce(&T) -> V) -> V {
+        let val = self.get();
+        f(&val)
+    }
+
     /// replaces a properties evaluation/inbounds/value to be the same as
     /// target, while keeping it's dependents.
     /// WARNING: this method can introduce circular dependencies if one is not careful.

--- a/pax-runtime-api/src/refcell_debug.rs
+++ b/pax-runtime-api/src/refcell_debug.rs
@@ -1,0 +1,96 @@
+// Taken from: https://users.rust-lang.org/t/dump-all-refcell-borrows/28315/4
+::cfg_if::cfg_if! { if #[cfg(debug_assertions)] {
+    #[derive(
+        Debug,
+        Clone,
+        Default,
+        PartialEq, Eq,
+        PartialOrd, Ord,
+    )]
+    pub struct RefCell<T> {
+        pub ref_cell: ::core::cell::RefCell<T>,
+
+        pub last_borrow_context: ::core::cell::Cell<&'static str>,
+    }
+
+    impl<T> RefCell<T> {
+        pub fn new (value: T) -> Self
+        {
+            RefCell {
+                ref_cell: ::core::cell::RefCell::new(value),
+                last_borrow_context: ::core::cell::Cell::new(""),
+            }
+        }
+    }
+
+    #[macro_export]
+    macro_rules! borrow {(
+        $wrapper:expr
+    ) => ({
+        let wrapper = &$wrapper;
+        if let Ok(ret) = wrapper.ref_cell.try_borrow() {
+            wrapper
+                .last_borrow_context
+                .set(concat!(
+                    "was still borrowed from ",
+                    file!(), ":", line!(), ":", column!(),
+                    " on expression ",
+                    stringify!($wrapper),
+                ));
+            ret
+        } else {
+            panic!(
+                "Error, {} {}",
+                stringify!($wrapper),
+                wrapper.last_borrow_context.get(),
+            );
+        }
+    })}
+
+    #[macro_export]
+    macro_rules! borrow_mut {(
+        $wrapper:expr
+    ) => ({
+        let wrapper = &$wrapper;
+        if let Ok(ret) = $wrapper.ref_cell.try_borrow_mut() {
+            $wrapper
+                .last_borrow_context
+                .set(concat!(
+                    "was still mutably borrowed from ",
+                    file!(), ":", line!(), ":", column!(),
+                    " on expression ",
+                    stringify!($wrapper),
+                ));
+            ret
+        } else {
+            panic!(
+                "Error, {} {}",
+                stringify!($wrapper),
+                wrapper.last_borrow_context.get(),
+            );
+        }
+    })}
+
+    #[macro_export]
+    macro_rules! use_RefCell {() => (
+        use pax_runtime_api::RefCell;
+    )}
+} else {
+    #[macro_export]
+    macro_rules! borrow {(
+        $ref_cell:expr
+    ) => (
+        $ref_cell.borrow()
+    )}
+
+    #[macro_export]
+    macro_rules! borrow_mut {(
+        $ref_cell:expr
+    ) => (
+        $ref_cell.borrow_mut()
+    )}
+    #[macro_export]
+    macro_rules! use_RefCell {() => (
+        use ::core::cell::RefCell;
+    )}
+}}

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -22,4 +22,3 @@ wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
 pax-manifest = {version="0.14.9", path = "../pax-manifest"}
 pax-runtime-api = {version="0.14.9", path = "../pax-runtime-api"}
 cfg-if = "1.0.0"
->>>>>>> d24a467d (running, settings view opening, stroke/fill editor working)

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -21,3 +21,5 @@ pax-message = {path = "../pax-message", version="0.14.9"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
 pax-manifest = {version="0.14.9", path = "../pax-manifest"}
 pax-runtime-api = {version="0.14.9", path = "../pax-runtime-api"}
+cfg-if = "1.0.0"
+>>>>>>> d24a467d (running, settings view opening, stroke/fill editor working)

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -1,5 +1,6 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
+use_RefCell!();
 use crate::RuntimeContext;
 pub use pax_runtime_api::*;
 #[cfg(feature = "designtime")]
@@ -9,7 +10,6 @@ use {
 };
 
 #[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct NodeContext {
     /// The current global engine tick count
     pub frames_elapsed: Property<u64>,
@@ -25,7 +25,7 @@ pub struct NodeContext {
     pub slot_children: usize,
     /// Borrow of the RuntimeContext, used at least for exposing raycasting to userland
     #[allow(unused)]
-    pub(crate) runtime_context: Rc<RefCell<RuntimeContext>>,
+    pub(crate) runtime_context: Rc<RuntimeContext>,
 
     #[cfg(feature = "designtime")]
     pub designtime: Rc<RefCell<DesigntimeManager>>,
@@ -34,7 +34,7 @@ pub struct NodeContext {
 #[cfg(feature = "designtime")]
 impl NodeContext {
     pub fn raycast(&self, point: Point2<Window>) -> Vec<NodeInterface> {
-        let rc = self.runtime_context.borrow();
+        let rc = &self.runtime_context;
         let expanded_nodes = rc.get_elements_beneath_ray(point, false, vec![]);
         expanded_nodes
             .into_iter()
@@ -43,7 +43,7 @@ impl NodeContext {
     }
 
     pub fn get_nodes_by_global_id(&self, uni: UniqueTemplateNodeIdentifier) -> Vec<NodeInterface> {
-        let rc = self.runtime_context.borrow();
+        let rc = &self.runtime_context;
         let expanded_nodes = rc.get_expanded_nodes_by_global_ids(&uni);
         expanded_nodes
             .into_iter()
@@ -52,7 +52,7 @@ impl NodeContext {
     }
 
     pub fn get_nodes_by_id(&self, id: &str) -> Vec<NodeInterface> {
-        let rc = self.runtime_context.borrow();
+        let rc = &self.runtime_context;
         let expanded_nodes = rc.get_expanded_nodes_by_id(id);
         expanded_nodes
             .into_iter()

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -34,8 +34,9 @@ pub struct NodeContext {
 #[cfg(feature = "designtime")]
 impl NodeContext {
     pub fn raycast(&self, point: Point2<Window>) -> Vec<NodeInterface> {
-        let rc = &self.runtime_context;
-        let expanded_nodes = rc.get_elements_beneath_ray(point, false, vec![]);
+        let expanded_nodes = self
+            .runtime_context
+            .get_elements_beneath_ray(point, false, vec![]);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)
@@ -43,8 +44,7 @@ impl NodeContext {
     }
 
     pub fn get_nodes_by_global_id(&self, uni: UniqueTemplateNodeIdentifier) -> Vec<NodeInterface> {
-        let rc = &self.runtime_context;
-        let expanded_nodes = rc.get_expanded_nodes_by_global_ids(&uni);
+        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_global_ids(&uni);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)
@@ -52,8 +52,7 @@ impl NodeContext {
     }
 
     pub fn get_nodes_by_id(&self, id: &str) -> Vec<NodeInterface> {
-        let rc = &self.runtime_context;
-        let expanded_nodes = rc.get_expanded_nodes_by_id(id);
+        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_id(id);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -32,11 +32,10 @@ pub struct NodeContext {
 }
 
 #[cfg(feature = "designtime")]
-impl NodeContext<'_> {
+impl NodeContext {
     pub fn raycast(&self, point: Point2<Window>) -> Vec<NodeInterface> {
-        let expanded_nodes = self
-            .runtime_context
-            .get_elements_beneath_ray(point, false, vec![]);
+        let rc = self.runtime_context.borrow();
+        let expanded_nodes = rc.get_elements_beneath_ray(point, false, vec![]);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)
@@ -44,7 +43,8 @@ impl NodeContext<'_> {
     }
 
     pub fn get_nodes_by_global_id(&self, uni: UniqueTemplateNodeIdentifier) -> Vec<NodeInterface> {
-        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_global_ids(&uni);
+        let rc = self.runtime_context.borrow();
+        let expanded_nodes = rc.get_expanded_nodes_by_global_ids(&uni);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)
@@ -52,7 +52,8 @@ impl NodeContext<'_> {
     }
 
     pub fn get_nodes_by_id(&self, id: &str) -> Vec<NodeInterface> {
-        let expanded_nodes = self.runtime_context.get_expanded_nodes_by_id(id);
+        let rc = self.runtime_context.borrow();
+        let expanded_nodes = rc.get_expanded_nodes_by_id(id);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -102,7 +102,6 @@ impl InstanceNode for ComponentInstance {
         expanded_node.compute_flattened_slot_children();
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-runtime/src/conditional.rs
+++ b/pax-runtime/src/conditional.rs
@@ -71,9 +71,11 @@ impl InstanceNode for ConditionalInstance {
                         let env = Rc::clone(&cloned_expanded_node.stack);
                         let children = cloned_self.base().get_instance_children().borrow();
                         let children_with_envs = children.iter().cloned().zip(iter::repeat(env));
-                        cloned_expanded_node.generate_children(children_with_envs, &cloned_context)
+                        let res = cloned_expanded_node
+                            .generate_children(children_with_envs, &cloned_context);
+                        res
                     } else {
-                        cloned_expanded_node.generate_children(iter::empty(), &cloned_context)
+                        Vec::new()
                     }
                 },
                 &[dep],

--- a/pax-runtime/src/conditional.rs
+++ b/pax-runtime/src/conditional.rs
@@ -1,8 +1,8 @@
-use std::cell::RefCell;
 use std::{iter, rc::Rc};
+use_RefCell!();
 
 use pax_runtime_api::pax_value::ImplToFromPaxAny;
-use pax_runtime_api::Property;
+use pax_runtime_api::{borrow, use_RefCell, Property};
 
 use crate::api::Layer;
 use crate::{
@@ -47,7 +47,7 @@ impl InstanceNode for ConditionalInstance {
     fn handle_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
     ) {
         let weak_ref_self = Rc::downgrade(expanded_node);
         let cloned_self = Rc::clone(&self);
@@ -69,13 +69,13 @@ impl InstanceNode for ConditionalInstance {
                     };
                     if cond_expr.get() {
                         let env = Rc::clone(&cloned_expanded_node.stack);
-                        let children = cloned_self.base().get_instance_children().borrow();
+                        let children = borrow!(cloned_self.base().get_instance_children());
                         let children_with_envs = children.iter().cloned().zip(iter::repeat(env));
                         let res = cloned_expanded_node
                             .generate_children(children_with_envs, &cloned_context);
                         res
                     } else {
-                        Vec::new()
+                        cloned_expanded_node.generate_children(vec![], &cloned_context)
                     }
                 },
                 &[dep],

--- a/pax-runtime/src/conditional.rs
+++ b/pax-runtime/src/conditional.rs
@@ -83,7 +83,6 @@ impl InstanceNode for ConditionalInstance {
             ));
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -710,19 +710,17 @@ impl std::fmt::Debug for ExpandedNode {
                 &Fmt(|f| borrow!(self.instance_node).resolve_debug(f, Some(self))),
             )
             .field("id", &self.id)
-            // .field("common_properties", &self.common_properties.try_borrow())
-            // .field("layout_properties", &self.layout_properties)
-            // .field("children", &self.children.get().iter().collect::<Vec<_>>())
-            // .field("parent", &self.parent_expanded_node.borrow().upgrade())
-            // .field(
-            //     "slot_children",
-            //     &self
-            //         .expanded_and_flattened_slot_children
-            //         .borrow()
-            //         .as_ref()
-            //         .map(|o| o.iter().map(|v| v.id).collect::<Vec<_>>()),
-            // )
-            // .field("occlusion_id", &self.occlusion_id.borrow())
+            .field("common_properties", &borrow!(self.common_properties))
+            .field("layout_properties", &self.layout_properties)
+            .field("children", &self.children.get().iter().collect::<Vec<_>>())
+            .field("parent", &borrow!(self.parent_expanded_node).upgrade())
+            .field(
+                "slot_children",
+                &borrow!(self.expanded_and_flattened_slot_children)
+                    .as_ref()
+                    .map(|o| o.iter().map(|v| v.id).collect::<Vec<_>>()),
+            )
+            .field("occlusion_id", &borrow!(self.occlusion_id))
             .field(
                 "containing_component",
                 &self.containing_component.upgrade().map(|v| v.id.clone()),

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -32,7 +32,7 @@ pub use expanded_node::ExpandedNode;
 use {
     self::node_interface::NodeLocal,
     pax_designtime::DesigntimeManager,
-    pax_runtime_api::{properties, Property, Window},
+    pax_runtime_api::{properties, Window},
 };
 
 use self::expanded_node::LayoutProperties;
@@ -272,16 +272,17 @@ impl PaxEngine {
         properties::register_time(&frames_elapsed);
         let globals = Globals {
             frames_elapsed,
-            viewport: TransformAndBounds {
-                transform: Transform2::default(),
-                bounds: viewport_size,
+            viewport: LayoutProperties {
+                transform: Property::new(Transform2::identity()),
+                bounds: Property::new(viewport_size),
             },
             platform,
             os,
             designtime: designtime.clone(),
         };
 
-        let mut runtime_context = RuntimeContext::new(expression_table, globals);
+        let mut runtime_context =
+            Rc::new(RefCell::new(RuntimeContext::new(expression_table, globals)));
 
         let root_node =
             ExpandedNode::root(Rc::clone(&main_component_instance), &mut runtime_context);

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -357,8 +357,8 @@ impl PaxEngine {
             let parent_template = borrow!(parent.instance_node);
             let children = borrow!(parent_template.base().get_instance_children());
             let new_templates = children.clone().into_iter().zip(iter::repeat(env));
-            parent.generate_children(new_templates, ctx);
-            parent.recurse_update(ctx);
+            let children = parent.generate_children(new_templates, ctx);
+            parent.children.set(children);
         } else {
             for child in parent.children.get().iter() {
                 Self::recurse_remount_main_template_expanded_node(child, id, ctx);
@@ -378,10 +378,7 @@ impl PaxEngine {
             .runtime_context
             .get_expanded_nodes_by_global_ids(&unique_id);
         for node in nodes {
-            node.recreate_with_new_data(
-                new_instance.clone(),
-                self.runtime_context.expression_table(),
-            );
+            node.recreate_with_new_data(new_instance.clone(), &self.runtime_context);
         }
     }
 

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use pax_manifest::UniqueTemplateNodeIdentifier;
-use pax_runtime_api::pax_value::ToFromPaxAny;
+use pax_runtime_api::{borrow, pax_value::ToFromPaxAny};
 
 use crate::{
     api::math::{Point2, Space, Transform2},
@@ -31,15 +31,14 @@ impl Space for NodeLocal {}
 
 impl NodeInterface {
     pub fn global_id(&self) -> Option<UniqueTemplateNodeIdentifier> {
-        let instance_node = self.inner.instance_node.borrow();
+        let instance_node = borrow!(self.inner.instance_node);
         let base = instance_node.base();
         base.template_node_identifier.clone()
     }
 
     pub fn common_properties(&self) -> Properties {
         let cp = self.inner.get_common_properties();
-        let rot = cp
-            .borrow()
+        let rot = borrow!(cp)
             .rotate
             .as_ref()
             .map(|p| p.get().clone())
@@ -55,7 +54,7 @@ impl NodeInterface {
 
     pub fn origin(&self) -> Option<Point2<Window>> {
         let common_props = self.inner.get_common_properties();
-        let common_props = common_props.borrow();
+        let common_props = borrow!(common_props);
         let (width, height) = self.inner.layout_properties.bounds.get();
         let p_anchor = Point2::new(
             common_props
@@ -82,7 +81,7 @@ impl NodeInterface {
     }
 
     pub fn parent(&self) -> Option<NodeInterface> {
-        let parent = self.inner.parent_expanded_node.borrow();
+        let parent = borrow!(self.inner.parent_expanded_node);
         Some(parent.upgrade()?.into())
     }
 

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -48,7 +48,7 @@ impl NodeInterface {
         }
     }
 
-    pub fn with_properties<T: ToFromPaxAny>(&self, f: impl FnOnce(&mut T)) {
+    pub fn with_properties<V, T: ToFromPaxAny>(&self, f: impl FnOnce(&mut T) -> V) -> V {
         self.inner.with_properties_unwrapped(|tp: &mut T| f(tp))
     }
 

--- a/pax-runtime/src/layout.rs
+++ b/pax-runtime/src/layout.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use pax_runtime_api::{Numeric, Property, Window};
+use pax_runtime_api::{borrow, Numeric, Property, Window};
 
 use crate::api::math::{Generic, Transform2, Vector2};
 use crate::api::{Axis, Size, Transform2D};
@@ -23,7 +23,7 @@ pub fn compute_tab(
 
     let cp_container_bounds = container_bounds.clone();
     let common_props = node.get_common_properties();
-    let common_props = common_props.borrow();
+    let common_props = borrow!(common_props);
     let cp_width = common_props.width.clone();
     let cp_height = common_props.height.clone();
 
@@ -182,7 +182,9 @@ pub fn compute_tab(
                     .compute_transform2d_matrix(cp_bounds.get(), container_bounds.get())
                     .cast_spaces::<NodeLocal, NodeLocal>()
             };
-            container_transform.get() * desugared_transform * node_transform_property_computed
+            let res =
+                container_transform.get() * desugared_transform * node_transform_property_computed;
+            res
         },
         &all_transform_deps,
         &format!("transform of node {}", node.id.0),

--- a/pax-runtime/src/layout.rs
+++ b/pax-runtime/src/layout.rs
@@ -182,9 +182,7 @@ pub fn compute_tab(
                     .compute_transform2d_matrix(cp_bounds.get(), container_bounds.get())
                     .cast_spaces::<NodeLocal, NodeLocal>()
             };
-            let res =
-                container_transform.get() * desugared_transform * node_transform_property_computed;
-            res
+            container_transform.get() * desugared_transform * node_transform_property_computed
         },
         &all_transform_deps,
         &format!("transform of node {}", node.id.0),

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -59,6 +59,7 @@ impl NodeCache {
 
     // Remove this node from all relevant constant lookup cache structures
     fn remove_from_cache(&mut self, node: &Rc<ExpandedNode>) {
+        self.eid_to_node.remove(&node.id);
         if let Some(uni) = &borrow!(node.instance_node).base().template_node_identifier {
             self.uni_to_eid.remove(uni);
         }

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -159,6 +159,12 @@ pub trait InstanceNode {
     fn get_template(&self) -> Option<&InstanceNodePtrList> {
         None
     }
+
+    fn handle_text_change(&self, expanded_node: &Rc<ExpandedNode>, text: String) {
+        // no-op for most, except for TextInstance
+        // TODO find a more general framework for exposing callbacks into primitives
+        // that doesn't need a method like this for each form type (textbox, checkbox, etc)
+    }
 }
 
 pub struct BaseInstance {

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -46,7 +46,6 @@ pub enum NodeType {
     Primitive,
 }
 
-#[cfg(debug_assertions)]
 impl std::fmt::Debug for dyn InstanceNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.resolve_debug(f, None)
@@ -75,7 +74,6 @@ pub trait InstanceNode {
     where
         Self: Sized;
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -1,13 +1,13 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 
 use std::iter;
 use std::rc::Rc;
-
+use_RefCell!();
 use crate::api::{CommonProperties, RenderContext};
 use pax_manifest::UniqueTemplateNodeIdentifier;
 use pax_runtime_api::pax_value::PaxAny;
 use pax_runtime_api::properties::UntypedProperty;
+use pax_runtime_api::{borrow, use_RefCell};
 use piet::{Color, StrokeStyle};
 
 use crate::api::{Layer, Scroll};
@@ -81,12 +81,7 @@ pub trait InstanceNode {
     ) -> std::fmt::Result;
 
     /// Updates the expanded node, recomputing it's properties and possibly updating it's children
-    fn update(
-        self: Rc<Self>,
-        _expanded_node: &Rc<ExpandedNode>,
-        _context: &Rc<RefCell<RuntimeContext>>,
-    ) {
-    }
+    fn update(self: Rc<Self>, _expanded_node: &Rc<ExpandedNode>, _context: &Rc<RuntimeContext>) {}
 
     /// Second lifecycle method during each render loop, occurs after
     /// properties have been computed, but before rendering
@@ -97,7 +92,7 @@ pub trait InstanceNode {
     fn handle_pre_render(
         &self,
         expanded_node: &ExpandedNode,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
         rcs: &mut dyn RenderContext,
     ) {
         //no-op default implementation
@@ -111,7 +106,7 @@ pub trait InstanceNode {
     fn render(
         &self,
         expanded_node: &ExpandedNode,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
         rcs: &mut dyn RenderContext,
     ) {
     }
@@ -125,7 +120,7 @@ pub trait InstanceNode {
     fn handle_post_render(
         &self,
         expanded_node: &ExpandedNode,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
         rcs: &mut dyn RenderContext,
     ) {
         //no-op default implementation
@@ -139,10 +134,10 @@ pub trait InstanceNode {
     fn handle_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
     ) {
         let env = Rc::clone(&expanded_node.stack);
-        let children = self.base().get_instance_children().borrow();
+        let children = borrow!(self.base().get_instance_children());
         let children_with_envs = children.iter().cloned().zip(iter::repeat(env));
 
         let new_children = expanded_node.generate_children(children_with_envs, context);
@@ -152,11 +147,7 @@ pub trait InstanceNode {
     /// Fires during element unmount, when an element is about to be removed from the render tree (e.g. by a `Conditional`)
     /// A use-case: send a message to native renderers that a `Text` element should be removed
     #[allow(unused_variables)]
-    fn handle_unmount(
-        &self,
-        expanded_node: &Rc<ExpandedNode>,
-        context: &Rc<RefCell<RuntimeContext>>,
-    ) {
+    fn handle_unmount(&self, expanded_node: &Rc<ExpandedNode>, context: &Rc<RuntimeContext>) {
         //no-op default implementation
     }
     /// Invoked by event interrupts to pass scroll information to render node

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -57,7 +57,6 @@ impl InstanceNode for RepeatInstance {
         })
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,
@@ -129,7 +128,6 @@ impl InstanceNode for RepeatInstance {
                     let Some(cloned_expanded_node) = weak_ref_self.upgrade() else {
                         panic!("ran evaluator after expanded node dropped (repeat elem)")
                     };
-                    let id = cloned_expanded_node.id.0;
                     let source = source_expression.get();
                     let source_len = source.len();
                     if source_len == *last_length.borrow() {

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -137,15 +137,11 @@ impl InstanceNode for RepeatInstance {
                             let property_i = Property::new(i);
                             let cp_source_expression = source_expression.clone();
                             let property_elem = Property::computed_with_name(
-                                // TODOdag why is this triggering after children have been recomputed?
-                                // How to make outer recompute and drop this before evaluation?
-                                // somehow, this is accessed before children are during tick?
-                                //
                                 move || {
-                                    cp_source_expression.get().get(i).cloned() // .unwrap_or_else(|| panic!(
-                                                                               //     "engine error: tried to access index {} of an array source that now only contains {} elements",
-                                                                               //     i, cp_source_expression.get().len()
-                                                                               // )),
+                                    Some(Rc::clone(&cp_source_expression.get().get(i).unwrap_or_else(|| panic!(
+                                        "engine error: tried to access index {} of an array source that now only contains {} elements",
+                                        i, cp_source_expression.get().len()
+                                    ))))
                                 },
                                 &[source_expression.untyped()],
                                 "repeat elem",

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -129,6 +129,7 @@ impl InstanceNode for RepeatInstance {
                     let Some(cloned_expanded_node) = weak_ref_self.upgrade() else {
                         panic!("ran evaluator after expanded node dropped (repeat elem)")
                     };
+                    let id = cloned_expanded_node.id.0;
                     let source = source_expression.get();
                     let source_len = source.len();
                     if source_len == *last_length.borrow() {
@@ -143,6 +144,10 @@ impl InstanceNode for RepeatInstance {
                             let property_i = Property::new(i);
                             let cp_source_expression = source_expression.clone();
                             let property_elem = Property::computed_with_name(
+                                // TODOdag why is this triggering after children have been recomputed?
+                                // How to make outer recompute and drop this before evaluation?
+                                // somehow, this is accessed before children are during tick?
+                                //
                                 move || Some(Rc::clone(&cp_source_expression.get()[i])),
                                 &[source_expression.untyped()],
                                 "repeat elem",

--- a/pax-runtime/src/slot.rs
+++ b/pax-runtime/src/slot.rs
@@ -113,7 +113,6 @@ impl InstanceNode for SlotInstance {
         });
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-runtime/src/slot.rs
+++ b/pax-runtime/src/slot.rs
@@ -1,7 +1,7 @@
-use std::cell::RefCell;
 use std::rc::{Rc, Weak};
+use_RefCell!();
 
-use pax_runtime_api::{ImplToFromPaxAny, Numeric, Property};
+use pax_runtime_api::{borrow, use_RefCell, ImplToFromPaxAny, Numeric, Property};
 
 use crate::api::Layer;
 use crate::{
@@ -55,7 +55,7 @@ impl InstanceNode for SlotInstance {
     fn handle_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
-        context: &Rc<RefCell<RuntimeContext>>,
+        context: &Rc<RuntimeContext>,
     ) {
         let weak_ref_self = Rc::downgrade(expanded_node);
         let cloned_context = Rc::clone(context);
@@ -87,17 +87,14 @@ impl InstanceNode for SlotInstance {
             ));
     }
 
-    fn update(
-        self: Rc<Self>,
-        expanded_node: &Rc<ExpandedNode>,
-        _context: &Rc<RefCell<RuntimeContext>>,
-    ) {
+    fn update(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, _context: &Rc<RuntimeContext>) {
         let containing = expanded_node.containing_component.upgrade();
-        let nodes = containing
-            .as_ref()
-            .expect("slot to have a containing component")
-            .expanded_and_flattened_slot_children
-            .borrow();
+        let nodes = borrow!(
+            containing
+                .as_ref()
+                .expect("slot to have a containing component")
+                .expanded_and_flattened_slot_children
+        );
         expanded_node.with_properties_unwrapped(|properties: &mut SlotProperties| {
             let node_rc = nodes
                 .as_ref()

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -15,6 +15,7 @@ description = "Primitives crate for Pax's standard library"
 pax-runtime = {path = "../../pax-runtime", version="0.14.9"}
 pax-std = {path = "../", version="0.14.9"}
 pax-message = {path = "../../pax-message", version="0.14.9" }
+pax-runtime-api = {path = "../../pax-runtime-api", version="0.14.9"}
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"

--- a/pax-std/pax-std-primitives/src/button.rs
+++ b/pax-std/pax-std-primitives/src/button.rs
@@ -105,7 +105,7 @@ impl InstanceNode for ButtonInstance {
                             patch_if_needed(
                                 &mut old_state.content,
                                 &mut patch.content,
-                                properties.label.get().string.clone(),
+                                properties.label.get(),
                             ),
                             patch_if_needed(
                                 &mut old_state.style,

--- a/pax-std/pax-std-primitives/src/button.rs
+++ b/pax-std/pax-std-primitives/src/button.rs
@@ -150,7 +150,6 @@ impl InstanceNode for ButtonInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/checkbox.rs
+++ b/pax-std/pax-std-primitives/src/checkbox.rs
@@ -143,7 +143,6 @@ impl InstanceNode for CheckboxInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -78,7 +78,6 @@ impl InstanceNode for EllipseInstance {
         });
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -59,13 +59,19 @@ impl InstanceNode for EllipseInstance {
             rc.fill(&layer_id, transformed_bez_path, &color.into());
 
             //hack to address "phantom stroke" bug on Web
-            let width: f64 = properties.stroke.get().width.expect_pixels().to_float();
+            let width: f64 = properties
+                .stroke
+                .get()
+                .width
+                .get()
+                .expect_pixels()
+                .to_float();
 
             if width > f64::EPSILON {
                 rc.stroke(
                     &layer_id,
                     duplicate_transformed_bez_path,
-                    &properties.stroke.get().color.to_piet_color().into(),
+                    &properties.stroke.get().color.get().to_piet_color().into(),
                     width,
                 );
             }

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -1,11 +1,12 @@
 use kurbo::{Rect, Shape};
 use pax_runtime::api::{Fill, Layer, RenderContext};
 use pax_runtime::BaseInstance;
+use pax_runtime_api::{borrow, use_RefCell};
 use pax_std::primitives::Ellipse;
 
 use pax_runtime::{ExpandedNode, InstanceFlags, InstanceNode, InstantiationArgs, RuntimeContext};
 
-use std::cell::RefCell;
+use_RefCell!();
 use std::rc::Rc;
 
 /// A basic 2D vector ellipse, drawn to fill the bounds specified
@@ -35,7 +36,7 @@ impl InstanceNode for EllipseInstance {
     fn render(
         &self,
         expanded_node: &ExpandedNode,
-        _context: &Rc<RefCell<RuntimeContext>>,
+        _context: &Rc<RuntimeContext>,
         rc: &mut dyn RenderContext,
     ) {
         let tab = &expanded_node.layout_properties;
@@ -55,7 +56,7 @@ impl InstanceNode for EllipseInstance {
                 unimplemented!("gradients not supported on ellipse")
             };
 
-            let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+            let layer_id = format!("{}", borrow!(expanded_node.occlusion_id));
             rc.fill(&layer_id, transformed_bez_path, &color.into());
 
             //hack to address "phantom stroke" bug on Web

--- a/pax-std/pax-std-primitives/src/frame.rs
+++ b/pax-std/pax-std-primitives/src/frame.rs
@@ -208,7 +208,6 @@ impl InstanceNode for FrameInstance {
         self.native_message_props.borrow_mut().remove(&id);
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/group.rs
+++ b/pax-std/pax-std-primitives/src/group.rs
@@ -27,7 +27,6 @@ impl InstanceNode for GroupInstance {
         })
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -93,8 +93,7 @@ impl InstanceNode for ImageInstance {
                     let path_val = expanded_node
                         .with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
 
-                    let update =
-                        patch_if_needed(&mut old_state.path, &mut patch.path, path_val.string);
+                    let update = patch_if_needed(&mut old_state.path, &mut patch.path, path_val);
 
                     if update {
                         context
@@ -136,7 +135,7 @@ impl InstanceNode for ImageInstance {
         let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
         rc.save(&layer_id);
         rc.transform(&layer_id, transform.into());
-        rc.draw_image(&layer_id, &path.string, transformed_bounds);
+        rc.draw_image(&layer_id, &path, transformed_bounds);
         rc.restore(&layer_id);
     }
 

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -143,7 +143,6 @@ impl InstanceNode for ImageInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -4,10 +4,11 @@ use pax_runtime::api::{Layer, RenderContext};
 use pax_runtime::{
     BaseInstance, ExpandedNode, InstanceFlags, InstanceNode, InstantiationArgs, RuntimeContext,
 };
+use pax_runtime_api::{borrow, use_RefCell};
 use pax_std::primitives::Path;
 use pax_std::types::{PathElement, Point};
 
-use std::cell::RefCell;
+use_RefCell!();
 use std::rc::Rc;
 
 /// A basic 2D vector path for arbitrary Bézier / line-segment chains
@@ -36,10 +37,10 @@ impl InstanceNode for PathInstance {
     fn render(
         &self,
         expanded_node: &ExpandedNode,
-        _rtc: &Rc<RefCell<RuntimeContext>>,
+        _rtc: &Rc<RuntimeContext>,
         rc: &mut dyn RenderContext,
     ) {
-        let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+        let layer_id = format!("{}", borrow!(expanded_node.occlusion_id));
 
         expanded_node.with_properties_unwrapped(|properties: &mut Path| {
             let mut bez_path = BezPath::new();

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -122,7 +122,6 @@ impl InstanceNode for PathInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -93,12 +93,26 @@ impl InstanceNode for PathInstance {
 
             let color = properties.fill.get().to_piet_color();
             rc.fill(&layer_id, transformed_bez_path, &color.into());
-            if properties.stroke.get().width.expect_pixels().to_float() > f64::EPSILON {
+            if properties
+                .stroke
+                .get()
+                .width
+                .get()
+                .expect_pixels()
+                .to_float()
+                > f64::EPSILON
+            {
                 rc.stroke(
                     &layer_id,
                     duplicate_transformed_bez_path,
-                    &properties.stroke.get().color.to_piet_color().into(),
-                    properties.stroke.get().width.expect_pixels().to_float(),
+                    &properties.stroke.get().color.get().to_piet_color().into(),
+                    properties
+                        .stroke
+                        .get()
+                        .width
+                        .get()
+                        .expect_pixels()
+                        .to_float(),
                 );
             }
         });

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -94,7 +94,6 @@ impl InstanceNode for RectangleInstance {
         });
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -1,13 +1,14 @@
 use kurbo::{RoundedRect, Shape};
 use pax_runtime::{api::Fill, BaseInstance};
+use pax_runtime_api::{borrow, use_RefCell};
 use piet::{LinearGradient, RadialGradient};
 
 use pax_runtime::{ExpandedNode, InstanceFlags, InstanceNode, InstantiationArgs, RuntimeContext};
 use pax_std::primitives::Rectangle;
 
 use pax_runtime::api::{Layer, RenderContext};
-
-use std::{cell::RefCell, rc::Rc};
+use_RefCell!();
+use std::rc::Rc;
 
 /// A basic 2D vector rectangle, drawn to fill the bounds specified
 /// by `size`, transformed by `transform`
@@ -33,13 +34,13 @@ impl InstanceNode for RectangleInstance {
     fn render(
         &self,
         expanded_node: &ExpandedNode,
-        _rtc: &Rc<RefCell<RuntimeContext>>,
+        _rtc: &Rc<RuntimeContext>,
         rc: &mut dyn RenderContext,
     ) {
         let tab = &expanded_node.layout_properties;
         let (width, height) = tab.bounds.get();
 
-        let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+        let layer_id = format!("{}", borrow!(expanded_node.occlusion_id));
 
         expanded_node.with_properties_unwrapped(|properties: &mut Rectangle| {
             let rect = RoundedRect::new(0.0, 0.0, width, height, &properties.corner_radii.get());

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -76,12 +76,18 @@ impl InstanceNode for RectangleInstance {
             }
 
             //hack to address "phantom stroke" bug on Web
-            let width: f64 = properties.stroke.get().width.expect_pixels().to_float();
+            let width: f64 = properties
+                .stroke
+                .get()
+                .width
+                .get()
+                .expect_pixels()
+                .to_float();
             if width > f64::EPSILON {
                 rc.stroke(
                     &layer_id,
                     duplicate_transformed_bez_path,
-                    &properties.stroke.get().color.to_piet_color().into(),
+                    &properties.stroke.get().color.get().to_piet_color().into(),
                     width,
                 );
             }

--- a/pax-std/pax-std-primitives/src/scrollbar.rs
+++ b/pax-std/pax-std-primitives/src/scrollbar.rs
@@ -171,7 +171,6 @@ impl InstanceNode for ScrollbarInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -145,6 +145,11 @@ impl InstanceNode for TextInstance {
                                 &mut patch.style_link,
                                 (&properties.style_link.get()).into(),
                             ),
+                            patch_if_needed(
+                                &mut old_state.editable,
+                                &mut patch.editable,
+                                properties.editable.get(),
+                            ),
                             // Transform and bounds
                             patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
                             patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),
@@ -190,5 +195,9 @@ impl InstanceNode for TextInstance {
 
     fn base(&self) -> &BaseInstance {
         &self.base
+    }
+
+    fn handle_text_change(&self, expanded_node: &Rc<ExpandedNode>, text: String) {
+        expanded_node.with_properties_unwrapped(|properties: &mut Text| properties.text.set(text));
     }
 }

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -139,7 +139,7 @@ impl InstanceNode for TextInstance {
                             patch_if_needed(
                                 &mut old_state.content,
                                 &mut patch.content,
-                                properties.text.get().string.clone(),
+                                properties.text.get(),
                             ),
                             // Styles
                             patch_if_needed(

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -190,7 +190,6 @@ impl InstanceNode for TextInstance {
             .remove(&expanded_node.id);
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/textbox.rs
+++ b/pax-std/pax-std-primitives/src/textbox.rs
@@ -177,7 +177,6 @@ impl InstanceNode for TextboxInstance {
         &self.base
     }
 
-    #[cfg(debug_assertions)]
     fn resolve_debug(
         &self,
         f: &mut std::fmt::Formatter,

--- a/pax-std/pax-std-primitives/src/textbox.rs
+++ b/pax-std/pax-std-primitives/src/textbox.rs
@@ -124,12 +124,12 @@ impl InstanceNode for TextboxInstance {
                             patch_if_needed(
                                 &mut old_state.stroke_color,
                                 &mut patch.stroke_color,
-                                (&properties.stroke.get().color).into(),
+                                (&properties.stroke.get().color.get()).into(),
                             ),
                             patch_if_needed(
                                 &mut old_state.stroke_width,
                                 &mut patch.stroke_width,
-                                properties.stroke.get().width.get_pixels(width),
+                                properties.stroke.get().width.get().get_pixels(width),
                             ),
                             patch_if_needed(
                                 &mut old_state.background,

--- a/pax-std/pax-std-primitives/src/textbox.rs
+++ b/pax-std/pax-std-primitives/src/textbox.rs
@@ -107,7 +107,7 @@ impl InstanceNode for TextboxInstance {
                             patch_if_needed(
                                 &mut old_state.text,
                                 &mut patch.text,
-                                properties.text.get().string.clone(),
+                                properties.text.get(),
                             ),
                             patch_if_needed(&mut old_state.size_x, &mut patch.size_x, width),
                             patch_if_needed(&mut old_state.size_y, &mut patch.size_y, height),

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -12,7 +12,7 @@ pub mod components {
 
 pub mod primitives {
     use pax_engine::pax;
-    use pax_runtime::api::{Color, Property, Size, StringBox, Stroke};
+    use pax_runtime::api::{Color, Property, Size, Stroke};
     use pax_runtime::api::{Fill, Numeric};
 
     use crate::types::text::TextStyle;
@@ -62,7 +62,7 @@ pub mod primitives {
     #[primitive("pax_std_primitives::text::TextInstance")]
     pub struct Text {
         pub editable: Property<bool>,
-        pub text: Property<StringBox>,
+        pub text: Property<String>,
         pub style: Property<TextStyle>,
         pub style_link: Property<TextStyle>,
     }
@@ -76,7 +76,7 @@ pub mod primitives {
     #[pax]
     #[primitive("pax_std_primitives::textbox::TextboxInstance")]
     pub struct Textbox {
-        pub text: Property<StringBox>,
+        pub text: Property<String>,
         pub background: Property<Color>,
         pub stroke: Property<Stroke>,
         pub border_radius: Property<Numeric>,
@@ -87,14 +87,14 @@ pub mod primitives {
     #[pax]
     #[primitive("pax_std_primitives::button::ButtonInstance")]
     pub struct Button {
-        pub label: Property<StringBox>,
+        pub label: Property<String>,
         pub style: Property<TextStyle>,
     }
 
     #[pax]
     #[primitive("pax_std_primitives::image::ImageInstance")]
     pub struct Image {
-        pub path: Property<StringBox>,
+        pub path: Property<String>,
     }
 
     #[pax]


### PR DESCRIPTION
Adds "double binding" behaviour to text instances, removes refcell around RuntimeContext, bug fixes, etc.

This PR includes changes to enable debug info about the last borrow location in debug mode, TBD if this should stay long term (more confusing for new contributors, but easier to debug borrow issues).

