### PR TITLE
Expression Eval using PaxAny

### DIFF
--- a/examples/src/space-game/src/lib.pax
+++ b/examples/src/space-game/src/lib.pax
@@ -1,10 +1,10 @@
 
 if self.game_state == "PLAYING" {
-	<Text x=10px y=10px text={self.score_text} style={fill:WHITE}/>
+	<Text x=10px y=10px text={"Score: " + self.score} style={fill:WHITE}/>
 }
 if self.game_state == "GAME_OVER" {
 	<Text y=25% height=25% text="GAME OVER" id=game_over/>
-	<Text y=50% height=25% text={self.score_text} id=game_over_score/>
+	<Text y=50% height=25% text={"Score: " + self.score} id=game_over_score/>
 	<Rectangle fill=rgba(255, 0, 50, 50)/>
 }
 

--- a/examples/src/space-game/src/lib.rs
+++ b/examples/src/space-game/src/lib.rs
@@ -34,7 +34,6 @@ pub struct SpaceGame {
 
     pub difficulty: Property<f64>,
     pub score: Property<u64>,
-    pub score_text: Property<String>,
 }
 
 #[pax]
@@ -181,7 +180,6 @@ impl SpaceGame {
         self.ship_y.set(ship_y);
         self.bullets.set(bullets);
         self.score.set(score);
-        self.score_text.set(format!("Score: {}", score));
 
         // Update tile background positions
         const BACKGROUND_SPEED: f64 = 5.0;

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -69,6 +69,7 @@ fn recurse_pratt_parse_to_string<'a>(
     pratt_parser: &PrattParser<Rule>,
     symbolic_ids: Rc<RefCell<Vec<String>>>,
 ) -> String {
+    // This is a hack to satisfy type checking,
     pratt_parser
         .map_primary(move |primary| match primary.as_rule() {
             /* expression_grouped | xo_enum_or_function_call | xo_range     */
@@ -181,7 +182,7 @@ fn recurse_pratt_parse_to_string<'a>(
                         let unit = inner.next().unwrap().as_str();
 
                         if unit == "px" {
-                            format!("Size::Pixels(({}.into()).to_pax_any()", value)
+                            format!("Size::Pixels({}.into()).to_pax_any()", value)
                         } else if unit == "%" {
                             format!("Percent({}.into()).to_pax_any()", value)
                         } else if unit == "deg" {
@@ -300,7 +301,7 @@ fn recurse_pratt_parse_to_string<'a>(
 
                 while let Some(item) = list.next() {
                     let item_str = recurse_pratt_parse_to_string(item.into_inner(), pratt_parser, Rc::clone(&symbolic_ids));
-                    vec.push(item_str);
+                    vec.push(item_str.trim_end_matches(".to_pax_any()").to_string());
                 }
                 format!("vec![{}]", vec.join(","))
             },

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -100,9 +100,9 @@ fn recurse_pratt_parse_to_string<'a>(
                    xo_enum_or_function_args_list = {expression_body ~ ("," ~ expression_body)*} */
 
                 if !primary.as_str().contains("(") {
-                    //If no args, we just want to return this xo_enum_or_function_call exactly,
-                    //such as StackerDirection::Vertical
-                    primary.as_str().to_string()
+                    //If no args, we just want to return this xo_enum_or_function_call wrapped in
+                    //a PaxAny
+                    format!("({}).to_pax_any()", primary.as_str())
                 } else {
                     //prepend identifiers; recurse-pratt-parse `xo_function_args`' `expression_body`s
                     let mut pairs = primary.into_inner();
@@ -127,7 +127,7 @@ fn recurse_pratt_parse_to_string<'a>(
                     }
                     output = output + ")";
 
-                    output
+                    format!("({}).to_pax_any()", output)
                 }
 
 
@@ -198,7 +198,7 @@ fn recurse_pratt_parse_to_string<'a>(
                         format!("({}).to_pax_any()", value)
                     },
                     Rule::string => {
-                        format!("({}).to_pax_any()",literal_kind.as_str().to_string())
+                        format!("({}).to_string().to_pax_any()",literal_kind.as_str().to_string())
                     },
                     Rule::literal_color => {
                         let mut inner = literal_kind.into_inner();

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -69,7 +69,6 @@ fn recurse_pratt_parse_to_string<'a>(
     pratt_parser: &PrattParser<Rule>,
     symbolic_ids: Rc<RefCell<Vec<String>>>,
 ) -> String {
-    // This is a hack to satisfy type checking,
     pratt_parser
         .map_primary(move |primary| match primary.as_rule() {
             /* expression_grouped | xo_enum_or_function_call | xo_range     */
@@ -282,8 +281,6 @@ fn recurse_pratt_parse_to_string<'a>(
             },
             Rule::xo_symbol => {
                 symbolic_ids.borrow_mut().push(primary.as_str().to_string());
-                // symbols should enter expressions as PaxAny already
-                // TODOexp remove to_pax_any here and instead pass them in as anys during eval
                 format!("({}).to_pax_any()",convert_symbolic_binding_from_paxel_to_ril(primary))
             },
             Rule::xo_tuple => {
@@ -292,7 +289,8 @@ fn recurse_pratt_parse_to_string<'a>(
                 let exp1 = tuple.next().unwrap();
                 let exp0 = recurse_pratt_parse_to_string( exp0.into_inner(), pratt_parser, Rc::clone(&symbolic_ids));
                 let exp1 = recurse_pratt_parse_to_string( exp1.into_inner(), pratt_parser, Rc::clone(&symbolic_ids));
-                // TODOexpr how to handle tuple type, or vec?
+                let exp0 = exp0.trim_end_matches(".to_pax_any()");
+                let exp1 = exp1.trim_end_matches(".to_pax_any()");
                 format!("({},{})", exp0, exp1)
             },
             Rule::xo_list => {

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -1637,21 +1637,6 @@ impl Reflectable for pax_runtime::api::Transform2D {
     }
 }
 
-impl Reflectable for pax_runtime::api::StringBox {
-    fn get_import_path() -> String {
-        "pax_engine::api::StringBox".to_string()
-    }
-    fn get_self_pascal_identifier() -> String {
-        "StringBox".to_string()
-    }
-    fn get_type_id() -> TypeId {
-        TypeId::build_singleton(
-            &Self::get_import_path(),
-            Some(&Self::get_self_pascal_identifier()),
-        )
-    }
-}
-
 impl<T: Reflectable> Reflectable for std::vec::Vec<T> {
     fn parse_to_manifest(mut ctx: ParsingContext) -> (ParsingContext, Vec<PropertyDefinition>) {
         let type_id = Self::get_type_id();

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -496,7 +496,9 @@ impl DefinitionToInstanceTraverser {
                                 Some(
                                     Property::computed_with_name(move || {
                                         let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, vtable_id);
-                                        let coerced = new_value_wrapped.try_coerce::<std::ops::Range::<isize>>().unwrap();
+                                        let coerced = new_value_wrapped.try_coerce::<std::ops::Range::<isize>>().map_err(|e| {
+                                            format!("err: {:?} for vtable_id {:?}", e, vtable_id)
+                                        }).unwrap();
                                         coerced
                                     }, &dependencies, "repeat source range")
                                 )

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -61,7 +61,7 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
 
                             let elem_borrowed = borrow!(elem);
                             if let Ok(unwrapped) = <{{invocation.fully_qualified_iterable_type}}>::ref_from_pax_any(&*elem_borrowed) {
-                                StringBox::from(unwrapped)
+                                unwrapped
                             } else {
                                 panic!();//Failed to unpack string from PaxAny
                             }
@@ -92,8 +92,8 @@ pub fn instantiate_expression_table() -> HashMap<usize, Box<dyn Fn(ExpressionCon
                             //binding simple numeric property
                             Numeric::from(p.{{invocation.root_identifier}}.get())
                         {% elif invocation.is_string %}
-                            //binding simple stringbox property
-                            StringBox::from(p.{{invocation.root_identifier}}.get())
+                            //binding simple string property
+                            p.{{invocation.root_identifier}}.get()
                         {% else %}
                             //binding cloneable property
                             p.{{invocation.root_identifier}}.get().clone()

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -35,7 +35,9 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                                 let cloned_table = table.clone();
                                 Property::computed_with_name(move || {
                                     let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
-                                    let coerced = new_value_wrapped.try_coerce::<{{property.property_type.type_id._type_id}}>().unwrap();
+                                    let coerced = new_value_wrapped.try_coerce::<{{property.property_type.type_id._type_id}}>()
+                                        .map_err(|e| format!("failed to coerce value from vtable_id: {}, {}", info.vtable_id, e))
+                                    .unwrap();
                                     coerced
                                 }, &dependents, &token.raw_value)
                             } else {

--- a/pax-macro/src/parsing.rs
+++ b/pax-macro/src/parsing.rs
@@ -1,4 +1,4 @@
-use pax_lang::{parse_pax_str, Pair, Pairs, Parser, PaxParser, Rule};
+use pax_lang::{parse_pax_str, Pair, Rule};
 
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/pax-manifest/src/deserializer/helpers.rs
+++ b/pax-manifest/src/deserializer/helpers.rs
@@ -6,7 +6,7 @@ use serde::{
 use pax_lang::{Parser, PaxParser, Rule};
 use pax_runtime_api::constants::{COLOR_CHANNEL, INTEGER, PERCENT};
 
-use crate::constants::{NUMERIC, STRING_BOX};
+use crate::constants::NUMERIC;
 
 use super::{
     error::{Error, Result},
@@ -387,15 +387,6 @@ impl<'de> MapAccess<'de> for PaxObject {
     where
         V: DeserializeSeed<'de>,
     {
-        if let Some(name) = &self.name {
-            if name == STRING_BOX {
-                let val =
-                    seed.deserialize(PrimitiveDeserializer::new(&self.elements[self.index].1))?;
-                self.index += 1;
-                return Ok(val);
-            }
-        }
-
         if self.index < self.elements.len() {
             let val = seed.deserialize(Deserializer::from_string(
                 self.elements[self.index].1.clone(),

--- a/pax-manifest/src/deserializer/mod.rs
+++ b/pax-manifest/src/deserializer/mod.rs
@@ -16,7 +16,7 @@ use self::helpers::{PaxColor, PaxEnum, PaxObject, PaxSeq};
 pub use error::{Error, Result};
 
 use crate::constants::{
-    COLOR, DEGREES, F64, NUMERIC, PERCENT, PIXELS, RADIANS, ROTATION, SIZE, STRING_BOX, TRUE,
+    COLOR, DEGREES, F64, NUMERIC, PERCENT, PIXELS, RADIANS, ROTATION, SIZE, TRUE,
 };
 
 use crate::deserializer::helpers::{ColorFuncArg, PaxSeqArg};

--- a/pax-runtime-api/src/constants.rs
+++ b/pax-runtime-api/src/constants.rs
@@ -2,7 +2,6 @@
 pub const NUMERIC: &str = "Numeric";
 pub const SIZE: &str = "Size";
 pub const ROTATION: &str = "Rotation";
-pub const STRING_BOX: &str = "StringBox";
 pub const DEGREES: &str = "Degrees";
 pub const RADIANS: &str = "Radians";
 pub const PIXELS: &str = "Pixels";

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -920,51 +920,6 @@ impl OcclusionLayerGen {
     }
 }
 
-impl Interpolatable for StringBox {}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(crate = "crate::serde")]
-pub struct StringBox {
-    pub string: String,
-}
-
-impl Add for StringBox {
-    type Output = Self;
-
-    fn add(mut self, rhs: Self) -> Self::Output {
-        self.string.push_str(&rhs.string.as_str());
-        self
-    }
-}
-
-impl From<&str> for StringBox {
-    fn from(value: &str) -> Self {
-        StringBox {
-            string: value.to_string(),
-        }
-    }
-}
-
-impl From<String> for StringBox {
-    fn from(value: String) -> Self {
-        StringBox { string: value }
-    }
-}
-
-impl From<&String> for StringBox {
-    fn from(value: &String) -> Self {
-        StringBox {
-            string: value.to_string(),
-        }
-    }
-}
-
-impl From<StringBox> for String {
-    fn from(value: StringBox) -> Self {
-        value.string
-    }
-}
-
 /// Raw Percent type, which we use for serialization and dynamic traversal.  At the time
 /// of authoring, this type is not used directly at runtime, but is intended for `into` coercion
 /// into downstream types, e.g. ColorChannel, Rotation, and Size.  This allows us to be "dumb"

--- a/pax-runtime-api/src/pax_value/arithmetic.rs
+++ b/pax-runtime-api/src/pax_value/arithmetic.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
-use crate::{PaxValue, ToFromPaxValue};
+use crate::{PaxValue, Percent, Size, ToFromPaxValue};
 
 use super::{PaxAny, ToFromPaxAny};
 
@@ -12,10 +12,17 @@ impl Add for PaxValue {
 
     fn add(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
+            // Basic types
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a + b).to_pax_value(),
             (PaxValue::String(a), PaxValue::String(b)) => (a + &b).to_pax_value(),
             (PaxValue::String(a), PaxValue::Numeric(b)) => (a + &b.to_string()).to_pax_value(),
             (PaxValue::Numeric(a), PaxValue::String(b)) => (a.to_string() + &b).to_pax_value(),
+
+            // Size and Percent
+            (PaxValue::Size(a), PaxValue::Size(b)) => (a + b).to_pax_value(),
+            (PaxValue::Percent(a), PaxValue::Percent(b)) => (Percent(a.0 + b.0)).to_pax_value(),
+            (PaxValue::Percent(a), PaxValue::Size(b))
+            | (PaxValue::Size(b), PaxValue::Percent(a)) => (Size::Percent(a.0) + b).to_pax_value(),
             (a, b) => panic!("can't add {:?} and {:?}", a, b),
         }
     }
@@ -38,6 +45,11 @@ impl Sub for PaxValue {
     fn sub(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a - b).to_pax_value(),
+            // Size and Percent
+            (PaxValue::Size(a), PaxValue::Size(b)) => (a - b).to_pax_value(),
+            (PaxValue::Percent(a), PaxValue::Percent(b)) => (Percent(a.0 - b.0)).to_pax_value(),
+            (PaxValue::Percent(a), PaxValue::Size(b)) => (Size::Percent(a.0) - b).to_pax_value(),
+            (PaxValue::Size(a), PaxValue::Percent(b)) => (a - Size::Percent(b.0)).to_pax_value(),
             (a, b) => panic!("can't subtract {:?} and {:?}", a, b),
         }
     }

--- a/pax-runtime-api/src/pax_value/arithmetic.rs
+++ b/pax-runtime-api/src/pax_value/arithmetic.rs
@@ -71,9 +71,6 @@ impl PartialEq for PaxValue {
             (PaxValue::Bool(a), PaxValue::Bool(b)) => a == b,
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => a == b,
             (PaxValue::String(a), PaxValue::String(b)) => a == b,
-            (PaxValue::StringBox(a), PaxValue::StringBox(b)) => a == b,
-            (PaxValue::String(a), PaxValue::StringBox(b)) => a == &b.string,
-            (PaxValue::StringBox(a), PaxValue::String(b)) => &a.string == b,
             (a, b) => panic!("can't compare {:?} and {:?}", a, b),
         }
     }

--- a/pax-runtime-api/src/pax_value/arithmetic.rs
+++ b/pax-runtime-api/src/pax_value/arithmetic.rs
@@ -1,0 +1,138 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use crate::{PaxValue, ToFromPaxValue};
+
+use super::{PaxAny, ToFromPaxAny};
+
+const ANY_ARITH_UNSUPPORTED: &'static str =
+    "types that are not representable as PaxValues are not supported in arithmetic expressions";
+//----------------------------PaxValue Arithmetic-----------------------------
+impl Add for PaxValue {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a + b).to_pax_value(),
+            (PaxValue::String(a), PaxValue::String(b)) => (a + &b).to_pax_value(),
+            (a, b) => panic!("can't add {:?} and {:?}", a, b),
+        }
+    }
+}
+
+impl Mul for PaxValue {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a * b).to_pax_value(),
+            (a, b) => panic!("can't multiply {:?} and {:?}", a, b),
+        }
+    }
+}
+
+impl Sub for PaxValue {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a - b).to_pax_value(),
+            (a, b) => panic!("can't subtract {:?} and {:?}", a, b),
+        }
+    }
+}
+
+impl Div for PaxValue {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a / b).to_pax_value(),
+            (a, b) => panic!("can't subtract {:?} and {:?}", a, b),
+        }
+    }
+}
+
+impl Neg for PaxValue {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            PaxValue::Numeric(a) => (-a).to_pax_value(),
+            a => panic!("can't negate {:?}", a),
+        }
+    }
+}
+
+impl PartialEq for PaxValue {
+    fn eq(&self, rhs: &Self) -> bool {
+        match (self, rhs) {
+            (PaxValue::Numeric(a), PaxValue::Numeric(b)) => a == b,
+            (a, b) => panic!("can't multiply {:?} and {:?}", a, b),
+        }
+    }
+}
+
+//----------------------------PaxAny Arithmetic-----------------------------
+impl Add for PaxAny {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxAny::Builtin(a), PaxAny::Builtin(b)) => (a + b).to_pax_any(),
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}
+
+impl Mul for PaxAny {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxAny::Builtin(a), PaxAny::Builtin(b)) => (a * b).to_pax_any(),
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}
+
+impl Sub for PaxAny {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxAny::Builtin(a), PaxAny::Builtin(b)) => (a - b).to_pax_any(),
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}
+
+impl Div for PaxAny {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (PaxAny::Builtin(a), PaxAny::Builtin(b)) => (a / b).to_pax_any(),
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}
+
+impl Neg for PaxAny {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            PaxAny::Builtin(a) => (-a).to_pax_any(),
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}
+
+impl PartialEq for PaxAny {
+    fn eq(&self, rhs: &Self) -> bool {
+        match (self, rhs) {
+            (PaxAny::Builtin(a), PaxAny::Builtin(b)) => a == b,
+            _ => panic!("{}", ANY_ARITH_UNSUPPORTED),
+        }
+    }
+}

--- a/pax-runtime-api/src/pax_value/arithmetic.rs
+++ b/pax-runtime-api/src/pax_value/arithmetic.rs
@@ -14,6 +14,8 @@ impl Add for PaxValue {
         match (self, rhs) {
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a + b).to_pax_value(),
             (PaxValue::String(a), PaxValue::String(b)) => (a + &b).to_pax_value(),
+            (PaxValue::String(a), PaxValue::Numeric(b)) => (a + &b.to_string()).to_pax_value(),
+            (PaxValue::Numeric(a), PaxValue::String(b)) => (a.to_string() + &b).to_pax_value(),
             (a, b) => panic!("can't add {:?} and {:?}", a, b),
         }
     }
@@ -47,7 +49,7 @@ impl Div for PaxValue {
     fn div(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a / b).to_pax_value(),
-            (a, b) => panic!("can't subtract {:?} and {:?}", a, b),
+            (a, b) => panic!("can't divide {:?} and {:?}", a, b),
         }
     }
 }
@@ -66,8 +68,13 @@ impl Neg for PaxValue {
 impl PartialEq for PaxValue {
     fn eq(&self, rhs: &Self) -> bool {
         match (self, rhs) {
+            (PaxValue::Bool(a), PaxValue::Bool(b)) => a == b,
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => a == b,
-            (a, b) => panic!("can't multiply {:?} and {:?}", a, b),
+            (PaxValue::String(a), PaxValue::String(b)) => a == b,
+            (PaxValue::StringBox(a), PaxValue::StringBox(b)) => a == b,
+            (PaxValue::String(a), PaxValue::StringBox(b)) => a == &b.string,
+            (PaxValue::StringBox(a), PaxValue::String(b)) => &a.string == b,
+            (a, b) => panic!("can't compare {:?} and {:?}", a, b),
         }
     }
 }

--- a/pax-runtime-api/src/pax_value/coercion_impls.rs
+++ b/pax-runtime-api/src/pax_value/coercion_impls.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     impl_default_coercion_rule, Color, ColorChannel, Fill, ImplToFromPaxAny, Numeric, PaxValue,
-    Percent, Property, Rotation, Size, StringBox, Stroke, Transform2D,
+    Percent, Property, Rotation, Size, Stroke, Transform2D,
 };
 
 // Default coersion rules:
@@ -101,7 +101,6 @@ impl CoercionRules for String {
     fn try_coerce(pax_value: PaxValue) -> Result<Self, String> {
         Ok(match pax_value {
             PaxValue::String(s) => s,
-            PaxValue::StringBox(sb) => sb.string,
             PaxValue::Numeric(n) => {
                 if n.is_float() {
                     n.to_float().to_string()
@@ -110,21 +109,6 @@ impl CoercionRules for String {
                 }
             }
             _ => return Err(format!("{:?} can't be coerced into a String", pax_value)),
-        })
-    }
-}
-
-impl CoercionRules for StringBox {
-    fn try_coerce(pax_value: PaxValue) -> Result<Self, String> {
-        Ok(match pax_value {
-            PaxValue::String(s) => StringBox::from(s),
-            PaxValue::StringBox(sb) => sb,
-            PaxValue::Numeric(n) => StringBox::from(if n.is_float() {
-                n.to_float().to_string()
-            } else {
-                n.to_int().to_string()
-            }),
-            _ => return Err(format!("{:?} can't be coerced into a StringBox", pax_value)),
         })
     }
 }

--- a/pax-runtime-api/src/pax_value/coercion_impls.rs
+++ b/pax-runtime-api/src/pax_value/coercion_impls.rs
@@ -3,8 +3,8 @@
 // custom coercion rules can be implemented by a type
 
 use crate::{
-    impl_default_coercion_rule, Color, Fill, ImplToFromPaxAny, Numeric, PaxValue, Percent,
-    Property, Rotation, Size, StringBox, Stroke, Transform2D,
+    impl_default_coercion_rule, Color, ColorChannel, Fill, ImplToFromPaxAny, Numeric, PaxValue,
+    Percent, Property, Rotation, Size, StringBox, Stroke, Transform2D,
 };
 
 // Default coersion rules:
@@ -61,6 +61,17 @@ impl CoercionRules for Stroke {
             },
             PaxValue::Stroke(stroke) => stroke,
             _ => return Err(format!("{:?} can't be coerced into a Stroke", pax_value)),
+        })
+    }
+}
+
+impl CoercionRules for ColorChannel {
+    fn try_coerce(value: PaxValue) -> Result<Self, String> {
+        Ok(match value {
+            PaxValue::ColorChannel(color) => color,
+            PaxValue::Percent(perc) => ColorChannel::Percent(perc.0),
+            PaxValue::Numeric(num) => ColorChannel::Integer(num),
+            _ => return Err(format!("{:?} can't be coerced into a ColorChannel", value)),
         })
     }
 }

--- a/pax-runtime-api/src/pax_value/mod.rs
+++ b/pax-runtime-api/src/pax_value/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Color, ColorChannel, Fill, Percent, Rotation, Size, StringBox, Stroke, Transform2D};
+use crate::{Color, ColorChannel, Fill, Percent, Rotation, Size, Stroke, Transform2D};
 use std::any::{Any, TypeId};
 
 use self::numeric::Numeric;
@@ -24,7 +24,6 @@ pub enum PaxValue {
     Bool(bool),
     Numeric(Numeric),
     String(String),
-    StringBox(StringBox),
     Transform2D(Transform2D),
     Size(Size),
     Percent(Percent),

--- a/pax-runtime-api/src/pax_value/mod.rs
+++ b/pax-runtime-api/src/pax_value/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{Color, ColorChannel, Fill, Percent, Rotation, Size, Stroke, Transform2D};
-use std::any::{Any, TypeId};
+use std::any::Any;
 
 use self::numeric::Numeric;
 pub use coercion_impls::CoercionRules;

--- a/pax-runtime-api/src/pax_value/numeric.rs
+++ b/pax-runtime-api/src/pax_value/numeric.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Interpolatable;
@@ -17,6 +19,25 @@ pub enum Numeric {
     F32(f32),
     ISize(isize),
     USize(usize),
+}
+
+impl Display for Numeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Numeric::I8(v) => write!(f, "{}", v),
+            Numeric::I16(v) => write!(f, "{}", v),
+            Numeric::I32(v) => write!(f, "{}", v),
+            Numeric::I64(v) => write!(f, "{}", v),
+            Numeric::U8(v) => write!(f, "{}", v),
+            Numeric::U16(v) => write!(f, "{}", v),
+            Numeric::U32(v) => write!(f, "{}", v),
+            Numeric::U64(v) => write!(f, "{}", v),
+            Numeric::F64(v) => write!(f, "{}", v),
+            Numeric::F32(v) => write!(f, "{}", v),
+            Numeric::ISize(v) => write!(f, "{}", v),
+            Numeric::USize(v) => write!(f, "{}", v),
+        }
+    }
 }
 
 impl PartialEq for Numeric {

--- a/pax-runtime-api/src/pax_value/to_from_impls.rs
+++ b/pax-runtime-api/src/pax_value/to_from_impls.rs
@@ -14,7 +14,6 @@ use crate::Fill;
 use crate::Percent;
 use crate::Rotation;
 use crate::Size;
-use crate::StringBox;
 use crate::Stroke;
 use crate::Transform2D;
 
@@ -44,7 +43,6 @@ impl ImplToFromPaxAny for () {}
 impl<F: Space, T: Space> ImplToFromPaxAny for Transform2<F, T> {}
 
 impl_to_from_pax_value!(String, PaxValue::String);
-impl_to_from_pax_value!(StringBox, PaxValue::StringBox);
 impl_to_from_pax_value!(ColorChannel, PaxValue::ColorChannel);
 
 // Pax internal types

--- a/pax-runtime-api/src/pax_value/to_from_impls.rs
+++ b/pax-runtime-api/src/pax_value/to_from_impls.rs
@@ -9,6 +9,7 @@ use crate::impl_to_from_pax_value;
 use crate::math::Space;
 use crate::math::Transform2;
 use crate::Color;
+use crate::ColorChannel;
 use crate::Fill;
 use crate::Percent;
 use crate::Rotation;
@@ -44,6 +45,7 @@ impl<F: Space, T: Space> ImplToFromPaxAny for Transform2<F, T> {}
 
 impl_to_from_pax_value!(String, PaxValue::String);
 impl_to_from_pax_value!(StringBox, PaxValue::StringBox);
+impl_to_from_pax_value!(ColorChannel, PaxValue::ColorChannel);
 
 // Pax internal types
 impl_to_from_pax_value!(Numeric, PaxValue::Numeric);

--- a/pax-std/src/scroller.rs
+++ b/pax-std/src/scroller.rs
@@ -8,7 +8,7 @@ use pax_engine::api::Numeric;
 use pax_engine::api::{Event, Wheel};
 use pax_engine::api::{Property, Size, Transform2D};
 use pax_engine::*;
-use pax_runtime::api::{NodeContext, Platform, StringBox, TouchEnd, TouchMove, TouchStart, OS};
+use pax_runtime::api::{NodeContext, Platform, TouchEnd, TouchMove, TouchStart, OS};
 #[pax]
 #[inlined(
     <Frame>

--- a/pax-std/src/stacker.rs
+++ b/pax-std/src/stacker.rs
@@ -3,7 +3,7 @@ use crate::types::{StackerCell, StackerDirection};
 use pax_engine::api::Numeric;
 use pax_engine::api::{Property, Size, Transform2D};
 use pax_engine::*;
-use pax_runtime::api::{NodeContext, StringBox};
+use pax_runtime::api::NodeContext;
 
 /// Stacker lays out a series of nodes either
 /// vertically or horizontally (i.e. a single row or column) with a specified gutter in between

--- a/pax-std/src/types/text.rs
+++ b/pax-std/src/types/text.rs
@@ -1,4 +1,4 @@
-use pax_engine::api::{Color, Numeric, Property, Size, StringBox};
+use pax_engine::api::{Color, Numeric, Property, Size};
 use pax_engine::*;
 use pax_message::{
     ColorMessage, FontPatch, FontStyleMessage, FontWeightMessage, LocalFontMessage,
@@ -123,7 +123,7 @@ impl Default for Font {
 #[pax]
 #[custom(Default)]
 pub struct SystemFont {
-    pub family: StringBox,
+    pub family: String,
     pub style: FontStyle,
     pub weight: FontWeight,
 }
@@ -131,7 +131,7 @@ pub struct SystemFont {
 impl Default for SystemFont {
     fn default() -> Self {
         Self {
-            family: "Arial".to_string().into(),
+            family: "Arial".to_string(),
             style: FontStyle::Normal,
             weight: FontWeight::Normal,
         }
@@ -140,16 +140,16 @@ impl Default for SystemFont {
 
 #[pax]
 pub struct WebFont {
-    pub family: StringBox,
-    pub url: StringBox,
+    pub family: String,
+    pub url: String,
     pub style: FontStyle,
     pub weight: FontWeight,
 }
 
 #[pax]
 pub struct LocalFont {
-    pub family: StringBox,
-    pub path: StringBox,
+    pub family: String,
+    pub path: String,
     pub style: FontStyle,
     pub weight: FontWeight,
 }
@@ -259,19 +259,19 @@ impl From<Font> for FontPatch {
     fn from(font: Font) -> Self {
         match font {
             Font::System(system_font) => FontPatch::System(SystemFontMessage {
-                family: Some(system_font.family.string),
+                family: Some(system_font.family),
                 style: Some(system_font.style.into()),
                 weight: Some(system_font.weight.into()),
             }),
             Font::Web(web_font) => FontPatch::Web(WebFontMessage {
-                family: Some(web_font.family.string.into()),
-                url: Some(web_font.url.string.into()),
+                family: Some(web_font.family),
+                url: Some(web_font.url),
                 style: Some(web_font.style.into()),
                 weight: Some(web_font.weight.into()),
             }),
             Font::Local(local_font) => FontPatch::Local(LocalFontMessage {
-                family: Some(local_font.family.string),
-                path: Some(local_font.path.string.into()),
+                family: Some(local_font.family),
+                path: Some(local_font.path),
                 style: Some(local_font.style.into()),
                 weight: Some(local_font.weight.into()),
             }),
@@ -314,7 +314,7 @@ impl PartialEq<FontPatch> for Font {
                 system_font_patch
                     .family
                     .as_ref()
-                    .map_or(false, |family| *family == system_font.family.string)
+                    .map_or(false, |family| *family == system_font.family)
                     && system_font_patch
                         .style
                         .as_ref()
@@ -328,11 +328,11 @@ impl PartialEq<FontPatch> for Font {
                 web_font_patch
                     .family
                     .as_ref()
-                    .map_or(false, |family| *family == web_font.family.string)
+                    .map_or(false, |family| *family == web_font.family)
                     && web_font_patch
                         .url
                         .as_ref()
-                        .map_or(false, |url| *url == web_font.url.string)
+                        .map_or(false, |url| *url == web_font.url)
                     && web_font_patch
                         .style
                         .as_ref()
@@ -346,11 +346,11 @@ impl PartialEq<FontPatch> for Font {
                 local_font_patch
                     .family
                     .as_ref()
-                    .map_or(false, |family| *family == local_font.family.string)
+                    .map_or(false, |family| *family == local_font.family)
                     && local_font_patch
                         .path
                         .as_ref()
-                        .map_or(false, |path| *path == local_font.path.string)
+                        .map_or(false, |path| *path == local_font.path)
                     && local_font_patch
                         .style
                         .as_ref()
@@ -366,7 +366,7 @@ impl PartialEq<FontPatch> for Font {
 }
 
 impl Font {
-    pub fn system(family: StringBox, style: FontStyle, weight: FontWeight) -> Self {
+    pub fn system(family: String, style: FontStyle, weight: FontWeight) -> Self {
         Self::System(SystemFont {
             family,
             style,
@@ -374,7 +374,7 @@ impl Font {
         })
     }
 
-    pub fn web(family: StringBox, url: StringBox, style: FontStyle, weight: FontWeight) -> Self {
+    pub fn web(family: String, url: String, style: FontStyle, weight: FontWeight) -> Self {
         Self::Web(WebFont {
             family,
             url,
@@ -383,7 +383,7 @@ impl Font {
         })
     }
 
-    pub fn local(family: StringBox, path: StringBox, style: FontStyle, weight: FontWeight) -> Self {
+    pub fn local(family: String, path: String, style: FontStyle, weight: FontWeight) -> Self {
         Self::Local(LocalFont {
             family,
             path,

--- a/scripts/local_github_actions.sh
+++ b/scripts/local_github_actions.sh
@@ -1,0 +1,3 @@
+cargo test --verbose --workspace --exclude pax-chassis-macos --exclude pax-chassis-common --exclude pax-chassis-ios
+cargo fmt -- --check
+cargo clippy -- -D warnings


### PR DESCRIPTION
This adds arithmetic operations on PaxAny, and changes expression eval to use PaxAny, allowing Strings and arbitrary other type combinations to be added, and removing the need for StringBox.