### PR TITLE
Image fit attribute

### DIFF
--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -45,6 +45,7 @@ pub trait RenderContext {
     fn clip(&mut self, layer: &str, path: BezPath);
     fn load_image(&mut self, path: &str, image: &[u8], width: usize, height: usize);
     fn draw_image(&mut self, layer: &str, image_path: &str, rect: kurbo::Rect);
+    fn get_image_size(&mut self, image_path: &str) -> Option<(usize, usize)>;
     fn transform(&mut self, layer: &str, affine: kurbo::Affine);
     fn layers(&self) -> Vec<&str>;
 }

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -17,7 +17,7 @@ pub mod primitives {
 
     use crate::types::text::TextStyle;
 
-    use crate::types::PathElement;
+    use crate::types::{ImageFit, PathElement};
     #[pax]
     #[primitive("pax_std_primitives::frame::FrameInstance")]
     pub struct Frame {}
@@ -95,6 +95,7 @@ pub mod primitives {
     #[primitive("pax_std_primitives::image::ImageInstance")]
     pub struct Image {
         pub path: Property<String>,
+        pub fit: Property<ImageFit>,
     }
 
     #[pax]

--- a/pax-std/src/types/mod.rs
+++ b/pax-std/src/types/mod.rs
@@ -160,10 +160,10 @@ pub enum ImageFit {
     FillHorizontal,
     /// Scale the image to perfectly fit within it's bounds, choosing vertical or horizontal
     /// based on which of them makes it fill the container, possibly clipping parts of the image
-    #[default]
     Fill,
     /// Scale the image to perfectly fit within it's bounds, without clipping the image, possibly leaving some
     /// of the available container area embty.
+    #[default]
     Fit,
     /// Stretch the image to fit the container
     Stretch,

--- a/pax-std/src/types/mod.rs
+++ b/pax-std/src/types/mod.rs
@@ -150,3 +150,21 @@ impl RectangleCornerRadii {
         }
     }
 }
+
+/// Image fit/layout options
+#[pax]
+pub enum ImageFit {
+    /// Scale the image to perfectly fit within it's bounds vertically
+    FillVertical,
+    /// Scale the image to perfectly fit within it's bounds horizontally
+    FillHorizontal,
+    /// Scale the image to perfectly fit within it's bounds, choosing vertical or horizontal
+    /// based on which of them makes it fill the container, possibly clipping parts of the image
+    #[default]
+    Fill,
+    /// Scale the image to perfectly fit within it's bounds, without clipping the image, possibly leaving some
+    /// of the available container area embty.
+    Fit,
+    /// Stretch the image to fit the container
+    Stretch,
+}


### PR DESCRIPTION
This adds an optional parameter "fit" to images that allows for different modes of sizing to bounds:

```rust
/// Image fit/layout options
#[pax]
pub enum ImageFit {
    /// Scale the image to perfectly fit within it's bounds vertically
    FillVertical,
    /// Scale the image to perfectly fit within it's bounds horizontally
    FillHorizontal,
    /// Scale the image to perfectly fit within it's bounds, choosing vertical or horizontal
    /// based on which of them makes it fill the container, possibly clipping parts of the image
    Fill,
    /// Scale the image to perfectly fit within it's bounds, without clipping the image, possibly leaving some
    /// of the available container area embty.
    #[default]
    Fit,
    /// Stretch the image to fit the container
    Stretch,
}
```