### PR TITLE
Fix warnings/lints in pax

### DIFF
--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -4,7 +4,6 @@ use std::ops::{Add, Deref, Mul, Neg, Sub};
 use crate::math::Space;
 use kurbo::BezPath;
 pub use pax_value::numeric::Numeric;
-use pax_value::PaxAny;
 pub use pax_value::{ImplToFromPaxAny, PaxValue, ToFromPaxValue};
 use piet::{PaintBrush, UnitPoint};
 use properties::UntypedProperty;
@@ -355,6 +354,7 @@ pub enum Size {
 
 impl Neg for Size {
     type Output = Size;
+
     fn neg(self) -> Self::Output {
         match self {
             Size::Pixels(pix) => Size::Pixels(-pix),
@@ -366,6 +366,7 @@ impl Neg for Size {
 
 impl Add for Size {
     type Output = Size;
+
     fn add(self, rhs: Self) -> Self::Output {
         let mut pixel_component: Numeric = Default::default();
         let mut percent_component: Numeric = Default::default();
@@ -385,6 +386,7 @@ impl Add for Size {
 
 impl Add<Percent> for Size {
     type Output = Size;
+
     fn add(self, rhs: Percent) -> Self::Output {
         self + Size::Percent(rhs.0)
     }
@@ -392,6 +394,7 @@ impl Add<Percent> for Size {
 
 impl Sub<Percent> for Size {
     type Output = Size;
+
     fn sub(self, rhs: Percent) -> Self::Output {
         self - Size::Percent(rhs.0)
     }
@@ -399,6 +402,7 @@ impl Sub<Percent> for Size {
 
 impl Add<Size> for Percent {
     type Output = Size;
+
     fn add(self, rhs: Size) -> Self::Output {
         Size::Percent(self.0) + rhs
     }
@@ -406,6 +410,7 @@ impl Add<Size> for Percent {
 
 impl Sub<Size> for Percent {
     type Output = Size;
+
     fn sub(self, rhs: Size) -> Self::Output {
         Size::Percent(self.0) - rhs
     }
@@ -413,6 +418,7 @@ impl Sub<Size> for Percent {
 
 impl Sub for Size {
     type Output = Size;
+
     fn sub(self, rhs: Self) -> Self::Output {
         let mut pixel_component: Numeric = Default::default();
         let mut percent_component: Numeric = Default::default();
@@ -473,7 +479,8 @@ pub enum Axis {
 
 impl Size {
     //Evaluate a Size in the context of `bounds` and a target `axis`.
-    //Returns a `Pixel` value as a simple f64; calculates `Percent` with respect to `bounds` & `axis`
+    //Returns a `Pixel` value as a simple f64; calculates `Percent` with respect to `bounds` &
+    // `axis`
     pub fn evaluate(&self, bounds: (f64, f64), axis: Axis) -> f64 {
         let target_bound = match axis {
             Axis::X => bounds.0,
@@ -498,8 +505,8 @@ pub struct CommonProperty {
 }
 
 // Struct containing fields shared by all RenderNodes.
-// Each property here is special-cased by the compiler when parsing element properties (e.g. `<SomeElement width={...} />`)
-// Retrieved via <dyn InstanceNode>#get_common_properties
+// Each property here is special-cased by the compiler when parsing element properties (e.g.
+// `<SomeElement width={...} />`) Retrieved via <dyn InstanceNode>#get_common_properties
 
 #[derive(Debug, Default, Clone)]
 pub struct CommonProperties {
@@ -661,6 +668,7 @@ impl EasingEvaluators {
     fn linear(t: f64) -> f64 {
         t
     }
+
     #[allow(dead_code)]
     fn none(t: f64) -> f64 {
         if t == 1.0 {
@@ -669,17 +677,21 @@ impl EasingEvaluators {
             0.0
         }
     }
+
     fn in_quad(t: f64) -> f64 {
         t * t
     }
+
     fn out_quad(t: f64) -> f64 {
         1.0 - (1.0 - t) * (1.0 - t)
     }
+
     fn in_back(t: f64) -> f64 {
         const C1: f64 = 1.70158;
         const C3: f64 = C1 + 1.00;
         C3 * t * t * t - C1 * t * t
     }
+
     fn out_back(t: f64) -> f64 {
         const C1: f64 = 1.70158;
         const C3: f64 = C1 + 1.00;
@@ -747,7 +759,8 @@ impl<T1: Interpolatable, T2: Interpolatable> Interpolatable for (T1, T2) {}
 
 impl<I: Interpolatable> Interpolatable for Vec<I> {
     fn interpolate(&self, other: &Self, t: f64) -> Self {
-        //FUTURE: could revisit the following assertion/constraint, perhaps with a "don't-care" approach to disjoint vec elements
+        //FUTURE: could revisit the following assertion/constraint, perhaps with a "don't-care"
+        // approach to disjoint vec elements
         assert_eq!(
             self.len(),
             other.len(),
@@ -877,6 +890,7 @@ impl OcclusionLayerGen {
     pub fn get_current_layer(&mut self) -> Layer {
         self.layer.clone()
     }
+
     pub fn update_z_index(&mut self, layer: Layer) {
         match layer {
             Layer::DontCare => {}
@@ -1389,6 +1403,7 @@ impl Rotation {
 }
 impl Neg for Rotation {
     type Output = Rotation;
+
     fn neg(self) -> Self::Output {
         match self {
             Rotation::Degrees(deg) => Rotation::Degrees(-deg),
@@ -1630,8 +1645,8 @@ impl Mul for Size {
 /// `translate` represents an (x,y) affine translation
 /// `scale`     represents an (x,y) non-uniform affine scale
 /// `rotate`    represents a (z) affine rotation (intuitive 2D rotation)
-/// `anchor`    represents the "(0,0)" point of the render node as it relates to its own bounding box.
-///             By default that's the top-left of the element, but `anchor` allows that
+/// `anchor`    represents the "(0,0)" point of the render node as it relates to its own bounding
+/// box.             By default that's the top-left of the element, but `anchor` allows that
 ///             to be offset either by a pixel or percentage-of-element-size
 ///             for each of (x,y)
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -1665,19 +1680,23 @@ impl Transform2D {
         ret.scale = Some([x, y]);
         ret
     }
+
     ///Rotation over z axis
     pub fn rotate(z: Rotation) -> Self {
         let mut ret = Transform2D::default();
         ret.rotate = Some(z);
         ret
     }
+
     ///Translation across x-y plane, pixels
     pub fn translate(x: Size, y: Size) -> Self {
         let mut ret = Transform2D::default();
         ret.translate = Some([x, y]);
         ret
     }
-    ///Describe alignment of the (0,0) position of this element as it relates to its own bounding box
+
+    ///Describe alignment of the (0,0) position of this element as it relates to its own bounding
+    /// box
     pub fn anchor(x: Size, y: Size) -> Self {
         let mut ret = Transform2D::default();
         ret.anchor = Some([x, y]);

--- a/pax-runtime-api/src/pax_value/mod.rs
+++ b/pax-runtime-api/src/pax_value/mod.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{Color, ColorChannel, Fill, Percent, Rotation, Size, Stroke, Transform2D};
 use std::any::Any;
 

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -1,4 +1,5 @@
-use crate::{api::Property, ExpandedNodeIdentifier};
+use crate::api::Property;
+use crate::ExpandedNodeIdentifier;
 use_RefCell!();
 use std::collections::HashMap;
 use std::iter;
@@ -7,7 +8,9 @@ use std::rc::Rc;
 use kurbo::Affine;
 use pax_manifest::UniqueTemplateNodeIdentifier;
 use pax_message::{NativeMessage, OcclusionPatch};
-use pax_runtime_api::{borrow, borrow_mut, math::Transform2, pax_value::PaxAny, use_RefCell, OS};
+use pax_runtime_api::math::Transform2;
+use pax_runtime_api::pax_value::PaxAny;
+use pax_runtime_api::{borrow, borrow_mut, use_RefCell, OS};
 
 use crate::api::{KeyDown, KeyPress, KeyUp, Layer, NodeContext, OcclusionLayerGen, RenderContext};
 use piet::InterpolationMode;
@@ -20,11 +23,12 @@ use pax_runtime_api::Platform;
 pub mod node_interface;
 
 /// The atomic unit of rendering; also the container for each unique tuple of computed properties.
-/// Represents an expanded node, that is "expanded" in the context of computed properties and repeat expansion.
-/// For example, a Rectangle inside `for i in 0..3` and a `for j in 0..4` would have 12 expanded nodes representing the 12 virtual Rectangles in the
-/// rendered scene graph.
-/// `ExpandedNode`s are architecturally "type-blind" — while they store typed data e.g. inside `computed_properties` and `computed_common_properties`,
-/// they require coordinating with their "type-aware" [`InstanceNode`] to perform operations on those properties.
+/// Represents an expanded node, that is "expanded" in the context of computed properties and repeat
+/// expansion. For example, a Rectangle inside `for i in 0..3` and a `for j in 0..4` would have 12
+/// expanded nodes representing the 12 virtual Rectangles in the rendered scene graph.
+/// `ExpandedNode`s are architecturally "type-blind" — while they store typed data e.g. inside
+/// `computed_properties` and `computed_common_properties`, they require coordinating with their
+/// "type-aware" [`InstanceNode`] to perform operations on those properties.
 mod expanded_node;
 pub use expanded_node::ExpandedNode;
 
@@ -105,7 +109,7 @@ impl Default for HandlerRegistry {
     }
 }
 
-struct ImgData<R: piet::RenderContext> {
+pub struct ImgData<R: piet::RenderContext> {
     img: R::Image,
     size: (usize, usize),
 }
@@ -179,7 +183,8 @@ impl<R: piet::RenderContext> crate::api::RenderContext for Renderer<R> {
     }
 
     fn load_image(&mut self, path: &str, buf: &[u8], width: usize, height: usize) {
-        //is this okay!? we know it's the same kind of backend no matter what layer, but it might be storing data?
+        //is this okay!? we know it's the same kind of backend no matter what layer, but it might
+        // be storing data?
         let render_context = self.backends.values_mut().next().unwrap();
         let img = render_context
             .make_image(width, height, buf, piet::ImageFormat::RgbaSeparate)
@@ -241,14 +246,14 @@ impl ExpressionTable {
             let ec = ExpressionContext { stack_frame };
             (**evaluator)(ec)
         } else {
-            panic!() //unhandled error if an invalid id is passed or if vtable is incorrectly initialized
+            panic!() //unhandled error if an invalid id is passed or if vtable is incorrectly
+                     // initialized
         }
     }
 }
 
 /// Central instance of the PaxEngine and runtime, intended to be created by a particular chassis.
 /// Contains all rendering and runtime logic.
-///
 impl PaxEngine {
     #[cfg(not(feature = "designtime"))]
     pub fn new(
@@ -403,13 +408,13 @@ impl PaxEngine {
 
     /// Workhorse methods of every tick.  Will be executed up to 240 Hz.
     /// Three phases:
-    /// 1. Expand nodes & compute properties; recurse entire instance tree and evaluate ExpandedNodes, stitching
-    ///    together parent/child relationships between ExpandedNodes along the way.
-    /// 2. Compute layout (z-index & TransformAndBounds) by visiting ExpandedNode tree
-    ///    in rendering order, writing computed rendering-specific values to ExpandedNodes
-    /// 3. Render:
-    ///     a. find lowest node (last child of last node)
-    ///     b. start rendering, from lowest node on-up, throughout tree
+    /// 1. Expand nodes & compute properties; recurse entire instance tree and evaluate
+    ///    ExpandedNodes, stitching together parent/child relationships between ExpandedNodes along
+    ///    the way.
+    /// 2. Compute layout (z-index & TransformAndBounds) by visiting ExpandedNode tree in rendering
+    ///    order, writing computed rendering-specific values to ExpandedNodes
+    /// 3. Render: a. find lowest node (last child of last node) b. start rendering, from lowest
+    ///    node on-up, throughout tree
     pub fn tick(&mut self) -> Vec<NativeMessage> {
         //
         // 1. UPDATE NODES (properties, etc.). This part we should be able to

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -1,13 +1,12 @@
 use std::rc::Rc;
 
 use pax_manifest::UniqueTemplateNodeIdentifier;
-use pax_runtime_api::{borrow, pax_value::ToFromPaxAny, Size};
+use pax_runtime_api::pax_value::ToFromPaxAny;
+use pax_runtime_api::{borrow, Size};
 
-use crate::{
-    api::math::{Point2, Space, Transform2},
-    api::{Rotation, Window},
-    ExpandedNode,
-};
+use crate::api::math::{Point2, Space};
+use crate::api::{Rotation, Window};
+use crate::ExpandedNode;
 
 use super::expanded_node::LayoutProperties;
 


### PR DESCRIPTION
Just a minor cleanup. 

I did notice there wasn't a rustfmt set, so there may be some changes to header format or extra lines inserted.

Feel free to ignore, but defining the line widths and pax format rules would ease accepting fixes.

Also making it so warnings become failures helps keep the code clean.