### PR TITLE
Tree Local Storage

### DIFF
--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -11,6 +11,13 @@ use properties::UntypedProperty;
 pub mod refcell_debug;
 pub use refcell_debug::*;
 
+/// Marker trait that needs to be implemented for a struct for insertion and
+/// deletion in a store
+/// NOTE: Stored objects need to be UNIQUE for any given stack. Do not insert
+/// values with types that could potentially be used in another use case,
+/// instead create a local type only used for a single purpose
+pub trait Store: 'static {}
+
 #[cfg(feature = "designtime")]
 use {
     crate::math::Point2, crate::node_interface::NodeInterface, pax_designtime::DesigntimeManager,

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -1,8 +1,9 @@
 use std::rc::{Rc, Weak};
 
 use_RefCell!();
-use crate::{ExpandedNode, RuntimeContext, RuntimePropertiesStackFrame, Store};
+use crate::{ExpandedNode, RuntimeContext, RuntimePropertiesStackFrame};
 pub use pax_runtime_api::*;
+
 #[cfg(feature = "designtime")]
 use {
     crate::api::math::Point2, crate::node_interface::NodeInterface, crate::HandlerLocation,
@@ -35,7 +36,13 @@ pub struct NodeContext {
 }
 
 impl NodeContext {
-    pub fn push_local_store<T: Store>(&self, store: T) {}
+    pub fn push_local_store<T: Store>(&self, store: T) {
+        self.local_stack_frame.insert_stack_local_store(store);
+    }
+
+    pub fn peek_local_store<T: Store, V>(&self, f: impl FnOnce(&mut T) -> V) -> Result<V, String> {
+        self.local_stack_frame.peek_stack_local_store(f)
+    }
 
     pub fn dispatch_event(&self, identifier: &'static str) -> Result<(), String> {
         let component_origin = self

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -1,7 +1,7 @@
 use std::rc::{Rc, Weak};
 
 use_RefCell!();
-use crate::{ExpandedNode, RuntimeContext};
+use crate::{ExpandedNode, RuntimeContext, RuntimePropertiesStackFrame, Store};
 pub use pax_runtime_api::*;
 #[cfg(feature = "designtime")]
 use {
@@ -11,6 +11,8 @@ use {
 
 #[derive(Clone)]
 pub struct NodeContext {
+    /// Stack frame of this component, used to look up stores
+    pub(crate) local_stack_frame: Rc<RuntimePropertiesStackFrame>,
     /// Registered handlers on the instance node
     pub(crate) component_origin: Weak<ExpandedNode>,
     /// The current global engine tick count
@@ -33,6 +35,8 @@ pub struct NodeContext {
 }
 
 impl NodeContext {
+    pub fn push_local_store<T: Store>(&self, store: T) {}
+
     pub fn dispatch_event(&self, identifier: &'static str) -> Result<(), String> {
         let component_origin = self
             .component_origin

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -638,9 +638,6 @@ impl ExpandedNode {
             .upgrade()
             .ok_or_else(|| "can't dispatch from root (has no parent)".to_owned())?;
         let properties = borrow!(parent_component.properties);
-        // save id of parent component (thing with props)
-        // save registry
-        // save identifier
 
         for handler in borrow!(registry)
             .handlers

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -485,6 +485,7 @@ impl ExpandedNode {
         };
 
         NodeContext {
+            local_stack_frame: Rc::clone(&self.stack),
             component_origin: Weak::clone(&self.containing_component),
             frames_elapsed: globals.frames_elapsed.clone(),
             bounds_self,

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -7,10 +7,8 @@ use pax_runtime_api::properties::UntypedProperty;
 use pax_runtime_api::{borrow, borrow_mut, use_RefCell, Store};
 use_RefCell!();
 use std::any::{Any, TypeId};
-use std::cell::{Cell, Ref};
+use std::cell::Cell;
 use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
 use crate::{ExpandedNode, ExpressionTable, Globals};
@@ -328,11 +326,9 @@ impl RuntimePropertiesStackFrame {
                 .ok_or_else(|| format!("couldn't find store in local stack"))?;
         }
         let v = {
-            f(borrow_mut!(current.local_stores)
-                .get_mut(&type_id)
-                .unwrap()
-                .downcast_mut()
-                .unwrap())
+            let mut stores = borrow_mut!(current.local_stores);
+            let store = stores.get_mut(&type_id).unwrap().downcast_mut().unwrap();
+            f(store)
         };
         Ok(v)
     }

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -6,8 +6,11 @@ use pax_runtime_api::pax_value::PaxAny;
 use pax_runtime_api::properties::UntypedProperty;
 use pax_runtime_api::{borrow, borrow_mut, use_RefCell};
 use_RefCell!();
-use std::cell::Cell;
+use std::any::{Any, TypeId};
+use std::cell::{Cell, Ref};
 use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
 use crate::{ExpandedNode, ExpressionTable, Globals};
@@ -242,6 +245,33 @@ impl RuntimeContext {
     }
 }
 
+/// Marker trait that needs to be implemented for a struct for insertion and
+/// deletion in a store
+/// NOTE: Stored objects need to be UNIQUE for any given stack. Do not insert
+/// values with types that could potentially be used in another use case,
+/// instead create a local type only used for a single purpose
+pub trait Store: Clone {}
+
+/// Guard returned from peek_stack_local_store, to not have
+/// to clone the value out each time. All methods available
+/// on T is available on this since it implements deref
+pub struct StoreRef<T> {
+    local_store_found: Rc<RefCell<HashMap<TypeId, Box<dyn Any>>>>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Store + 'static> StoreRef<T> {
+    fn deref(&self) -> Ref<'_, T> {
+        Ref::map(borrow!(self.local_store_found), |local_store| {
+            local_store
+                .get(&TypeId::of::<T>())
+                .unwrap()
+                .downcast_ref()
+                .unwrap()
+        })
+    }
+}
+
 /// Data structure for a single frame of our runtime stack, including
 /// a reference to its parent frame and `properties` for
 /// runtime evaluation, e.g. of Expressions.  `RuntimePropertiesStackFrame`s also track
@@ -252,6 +282,7 @@ impl RuntimeContext {
 
 pub struct RuntimePropertiesStackFrame {
     symbols_within_frame: HashMap<String, UntypedProperty>,
+    local_stores: Rc<RefCell<HashMap<TypeId, Box<dyn Any>>>>,
     properties: Rc<RefCell<PaxAny>>,
     parent: Weak<RuntimePropertiesStackFrame>,
 }
@@ -264,6 +295,7 @@ impl RuntimePropertiesStackFrame {
         Rc::new(Self {
             symbols_within_frame,
             properties,
+            local_stores: Default::default(),
             parent: Weak::new(),
         })
     }
@@ -275,6 +307,7 @@ impl RuntimePropertiesStackFrame {
     ) -> Rc<Self> {
         Rc::new(RuntimePropertiesStackFrame {
             symbols_within_frame,
+            local_stores: Default::default(),
             parent: Rc::downgrade(&self),
             properties: Rc::clone(properties),
         })
@@ -301,6 +334,29 @@ impl RuntimePropertiesStackFrame {
         } else {
             self.parent.upgrade()?.resolve_symbol(symbol)
         }
+    }
+
+    pub fn insert_stack_local_store<T: Store + 'static>(&mut self, store: T) {
+        let type_id = TypeId::of::<T>();
+        borrow_mut!(self.local_stores).insert(type_id, Box::new(store));
+    }
+
+    pub fn peek_stack_local_store<T: Store + 'static>(
+        self: Rc<Self>,
+    ) -> Result<StoreRef<T>, String> {
+        let mut current = self;
+        let type_id = TypeId::of::<T>();
+
+        while borrow!(current.local_stores).contains_key(&type_id) {
+            current = current
+                .parent
+                .upgrade()
+                .ok_or_else(|| format!("couldn't find store in local stack"))?;
+        }
+        Ok(StoreRef {
+            local_store_found: Rc::clone(&current.local_stores),
+            _phantom: PhantomData,
+        })
     }
 
     pub fn resolve_symbol_as_erased_property(&self, symbol: &str) -> Option<UntypedProperty> {

--- a/tests/src/custom-events/src/inner_comp.rs
+++ b/tests/src/custom-events/src/inner_comp.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+use super::StoreExample;
 use pax_engine::api::*;
 use pax_engine::*;
 use pax_std::components::Stacker;
@@ -16,5 +17,8 @@ pub struct InnerComp {}
 impl InnerComp {
     pub fn clicked(&mut self, ctx: &NodeContext, event: Event<Click>) {
         ctx.dispatch_event("custom_event").unwrap();
+        ctx.peek_local_store(|store: &mut StoreExample| {
+            log::debug!("{}", store.i);
+        });
     }
 }

--- a/tests/src/custom-events/src/lib.pax
+++ b/tests/src/custom-events/src/lib.pax
@@ -3,4 +3,5 @@
 />
 
 @settings {
+    @mount: on_mount
 }

--- a/tests/src/custom-events/src/lib.rs
+++ b/tests/src/custom-events/src/lib.rs
@@ -15,7 +15,17 @@ pub use inner_comp::InnerComp;
 #[file("lib.pax")]
 pub struct Example {}
 
+pub struct StoreExample {
+    pub i: i32,
+}
+
+impl Store for StoreExample {}
+
 impl Example {
+    pub fn on_mount(&mut self, ctx: &NodeContext) {
+        ctx.push_local_store(StoreExample { i: 42 });
+    }
+
     pub fn custom_event_trigger(&mut self, ctx: &NodeContext) {
         log::debug!("custom event was triggered!");
     }

--- a/tests/src/playground/src/lib.rs
+++ b/tests/src/playground/src/lib.rs
@@ -16,15 +16,8 @@ pub struct Example {
     pub num_clicks: Property<usize>,
 }
 
-struct SomeStore {
-    i: i32,
-}
-
-impl Store for SomeStore {}
-
 impl Example {
     pub fn handle_pre_render(&mut self, ctx: &NodeContext) {
-        ctx.push_environment(SomeStore { i: 45 });
         let old_ticks = self.ticks.get();
         self.ticks.set((old_ticks + 1) % 255);
     }

--- a/tests/src/playground/src/lib.rs
+++ b/tests/src/playground/src/lib.rs
@@ -16,8 +16,15 @@ pub struct Example {
     pub num_clicks: Property<usize>,
 }
 
+struct SomeStore {
+    i: i32,
+}
+
+impl Store for SomeStore {}
+
 impl Example {
     pub fn handle_pre_render(&mut self, ctx: &NodeContext) {
+        ctx.push_environment(SomeStore { i: 45 });
         let old_ticks = self.ticks.get();
         self.ticks.set((old_ticks + 1) % 255);
     }


### PR DESCRIPTION
This adds the ability to store node tree local information, to be used for contextual children.

Use:

```rust
// get value:
ctx.peek_local_store::<SomeUserlandType>(|store| {
   /// userland logic here
});

// set value:
ctx.push_local_store(SomeUserlandTyle {});
```

any object inserted (or looked up) is required to implement the Store Marker trait.