### PR TITLE
Slot parsing fix + wheel event changed from passive to active

### DIFF
--- a/pax-chassis-web/interface/src/events/listeners.ts
+++ b/pax-chassis-web/interface/src/events/listeners.ts
@@ -104,7 +104,7 @@ export function setupEventListeners(chassis: PaxChassisWeb) {
         if (res.prevent_default) {
             evt.preventDefault();
         }
-    }, {"passive": true, "capture": true});
+    }, {"passive": false, "capture": true});
     window.addEventListener('mousedown', (evt) => {
         let button = getMouseButton(evt);
         // set non-existent window prop to keep track of value

--- a/pax-lang/src/pax.pest
+++ b/pax-lang/src/pax.pest
@@ -278,7 +278,7 @@ statement_control_flow = {(statement_if | statement_for | statement_slot)}
 
 statement_if = {"if" ~ expression_body ~ "{" ~ inner_nodes ~ "}"} //FUTURE: support else, else if
 statement_for = {"for" ~ statement_for_predicate_declaration ~ "in" ~ statement_for_source ~ "{" ~ inner_nodes ~ "}"}
-statement_slot = {"slot" ~ expression_body}
+statement_slot = {"slot" ~ ("(" ~ expression_body ~ ")")}
 
 //Examples:
 //for i | for (elem, i)


### PR DESCRIPTION
Added requirement for slot expression to be wrapped in "(" and ")". Changed wheel event from passive to active to allow cancellation (prevent user from accidentally navigating back/forward from the designer when panning).