### PR TITLE
Deterministic Builds

### DIFF
--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -82,10 +82,10 @@ impl PaxChassisWeb {
             .location()
             .search()
             .expect("no search exists");
-        // let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
-        //     .await
-        //     .expect("failed to fetch manifest from remote");
-        let manifest = serde_json::from_str(&pax_cartridge::INITIAL_MANIFEST).unwrap();
+        let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
+            .await
+            .expect("failed to fetch manifest from remote");
+        // let manifest = serde_json::from_str(&pax_cartridge::INITIAL_MANIFEST).unwrap();
 
         let mut definition_to_instance_traverser =
             pax_cartridge::DefinitionToInstanceTraverser::new(manifest);

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -85,7 +85,6 @@ impl PaxChassisWeb {
         let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
             .await
             .expect("failed to fetch manifest from remote");
-        // let manifest = serde_json::from_str(&pax_cartridge::INITIAL_MANIFEST).unwrap();
 
         let mut definition_to_instance_traverser =
             pax_cartridge::DefinitionToInstanceTraverser::new(manifest);

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -82,9 +82,10 @@ impl PaxChassisWeb {
             .location()
             .search()
             .expect("no search exists");
-        let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
-            .await
-            .expect("failed to fetch manifest from remote");
+        // let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
+        //     .await
+        //     .expect("failed to fetch manifest from remote");
+        let manifest = serde_json::from_str(&pax_cartridge::INITIAL_MANIFEST).unwrap();
 
         let mut definition_to_instance_traverser =
             pax_cartridge::DefinitionToInstanceTraverser::new(manifest);

--- a/pax-compiler/src/building/mod.rs
+++ b/pax-compiler/src/building/mod.rs
@@ -7,7 +7,7 @@ use flate2::read::GzDecoder;
 use libc::EXIT_FAILURE;
 use pax_manifest::{HostCrateInfo, PaxManifest};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs,
     path::PathBuf,
     str::FromStr,
@@ -108,7 +108,7 @@ pub fn update_type_id_prefixes_in_place(
     });
     std::mem::swap(&mut manifest.type_table, &mut updated_type_table);
 
-    let mut updated_component_table = HashMap::new();
+    let mut updated_component_table = BTreeMap::new();
     manifest.components.iter_mut().for_each(|c| {
         c.1.type_id.fully_qualify_type_id(host_crate_info);
 

--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -5,7 +5,7 @@ use pax_manifest::{
     PropertyDefinitionFlags, SettingElement, TemplateNodeId, Token, TypeDefinition, TypeId,
     TypeTable, ValueDefinition,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::RangeFrom;
 use std::slice::IterMut;
 
@@ -738,7 +738,7 @@ pub struct ExpressionCompilationContext<'a> {
     pub active_node_id: Option<TemplateNodeId>,
 
     /// All components, by ID
-    pub all_components: HashMap<TypeId, ComponentDefinition>,
+    pub all_components: BTreeMap<TypeId, ComponentDefinition>,
 
     /// Type table, used for looking up property types by string type_ids
     pub type_table: &'a TypeTable,

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 
 use pax_lang::{parse_pax_str, Assoc, Op, Pair, Pairs, Parser, PaxParser, PrattParser, Rule, Span};
@@ -1032,7 +1032,7 @@ pub struct ParsingContext {
 
     pub main_component_type_id: TypeId,
 
-    pub component_definitions: HashMap<TypeId, ComponentDefinition>,
+    pub component_definitions: BTreeMap<TypeId, ComponentDefinition>,
 
     pub template_map: HashMap<String, TypeId>,
 
@@ -1048,7 +1048,7 @@ impl Default for ParsingContext {
         Self {
             main_component_type_id: TypeId::default(),
             visited_type_ids: HashSet::new(),
-            component_definitions: HashMap::new(),
+            component_definitions: BTreeMap::new(),
             template_map: HashMap::new(),
             type_table: get_primitive_type_table(),
             template_node_definitions: ComponentTemplate::default(),

--- a/pax-compiler/templates/cartridge_generation/cartridge.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge.tera
@@ -14,6 +14,7 @@ use pax_runtime_api::pax_value::PaxAny;
 use pax_runtime_api::pax_value::ToFromPaxAny;
 use pax_runtime_api::{borrow, borrow_mut};
 use pax_runtime::api::pax_value::ToFromPaxValue;
+use std::collections::BTreeMap;
 
 pub const INITIAL_MANIFEST: &str = include_str!("../initial-manifest.json");
 
@@ -140,7 +141,7 @@ pub trait ComponentFactory {
     fn build_default_properties(&self) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<PaxAny>>>;
     
     /// Returns the CommonProperties factory based on the defined properties 
-    fn build_inline_common_properties(&self, defined_properties: HashMap<String,ValueDefinition>) ->Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>> {
+    fn build_inline_common_properties(&self, defined_properties: BTreeMap<String,ValueDefinition>) ->Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<CommonProperties>>> {
         Box::new(move |stack_frame , table | Rc::new(RefCell::new({
             let mut cp = CommonProperties::default();
             for (key, value) in &defined_properties {
@@ -189,7 +190,7 @@ pub trait ComponentFactory {
     }
 
     /// Returns the properties factory based on the defined properties
-    fn build_inline_properties(&self, defined_properties: HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<PaxAny>>>;
+    fn build_inline_properties(&self, defined_properties: BTreeMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<PaxAny>>>;
     
     /// Returns the requested closure for the handler registry based on the defined handlers for this component
     /// The argument type is extrapolated based on how the handler was used in the initial compiled template

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -7,7 +7,7 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
         Box::new(|_,_| Rc::new(RefCell::new({{component.pascal_identifier}}::default().to_pax_any())))
     }
 
-    fn build_inline_properties(&self, defined_properties: HashMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<PaxAny>>> {
+    fn build_inline_properties(&self, defined_properties: BTreeMap<String,ValueDefinition>) -> Box<dyn Fn(Rc<RuntimePropertiesStackFrame>, Rc<ExpressionTable>) -> Rc<RefCell<PaxAny>>> {
         Box::new(move |stack_frame , table | Rc::new(RefCell::new(
             {
         let mut properties = {{component.pascal_identifier}}::default();

--- a/pax-manifest/src/cartridge_generation/mod.rs
+++ b/pax-manifest/src/cartridge_generation/mod.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     constants::{COMMON_PROPERTIES, COMMON_PROPERTIES_TYPE},
@@ -163,11 +163,11 @@ impl PaxManifest {
         &self,
         containing_component_type_id: &TypeId,
         tnd: &TemplateNodeDefinition,
-    ) -> HashMap<String, ValueDefinition> {
+    ) -> BTreeMap<String, ValueDefinition> {
         let component = self.components.get(&containing_component_type_id).unwrap();
         let settings =
             Self::merge_inline_settings_with_settings_block(&tnd.settings, &component.settings);
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
         if let Some(settings) = &settings {
             for setting in settings {
                 if let SettingElement::Setting(key, value) = setting {
@@ -190,11 +190,11 @@ impl PaxManifest {
         &self,
         containing_component_type_id: &TypeId,
         tnd: &TemplateNodeDefinition,
-    ) -> HashMap<String, ValueDefinition> {
+    ) -> BTreeMap<String, ValueDefinition> {
         let component = self.components.get(containing_component_type_id).unwrap();
         let settings =
             Self::merge_inline_settings_with_settings_block(&tnd.settings, &component.settings);
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
         if let Some(settings) = &settings {
             for setting in settings {
                 if let SettingElement::Setting(key, value) = setting {
@@ -311,7 +311,7 @@ impl PaxManifest {
             }
         }
 
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
 
         // Iterate in reverse order of priority (class, then id, then inline)
         for e in class_settings.into_iter() {

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -1752,6 +1752,17 @@ pub struct Token {
     pub token_location: Option<LocationInfo>,
 }
 
+impl PartialOrd for Token {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.raw_value.partial_cmp(&other.raw_value)
+    }
+}
+impl Ord for Token {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.raw_value.cmp(&other.raw_value)
+    }
+}
+
 impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
         self.raw_value == other.raw_value

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -1,5 +1,5 @@
 use std::borrow::Borrow;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::Display;
 use std::hash::Hasher;
 use std::{cmp::Ordering, hash::Hash};
@@ -23,8 +23,8 @@ pub mod deserializer;
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "pax_message::serde")]
 pub struct PaxManifest {
-    #[serde_as(as = "HashMap<serde_with::json::JsonString, _>")]
-    pub components: HashMap<TypeId, ComponentDefinition>,
+    #[serde_as(as = "BTreeMap<serde_with::json::JsonString, _>")]
+    pub components: BTreeMap<TypeId, ComponentDefinition>,
     pub main_component_type_id: TypeId,
     pub expression_specs: Option<HashMap<usize, ExpressionSpec>>,
     #[serde_as(as = "HashMap<serde_with::json::JsonString, _>")]
@@ -364,6 +364,18 @@ pub struct TypeId {
 
     _type_id: String,
     _type_id_escaped: String,
+}
+
+impl PartialOrd for TypeId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self._type_id.partial_cmp(&other._type_id)
+    }
+}
+
+impl Ord for TypeId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self._type_id.cmp(&other._type_id)
+    }
 }
 
 impl ImplToFromPaxAny for TypeId {}


### PR DESCRIPTION
This swaps map implementation from HashMap to BTreeMap in relevant spots to deterministically produce the same vtable IDs for the same project.