### PR TITLE
Load manifest from build in Designtime

### DIFF
--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -77,20 +77,12 @@ impl PaxChassisWeb {
     #[cfg(feature = "designtime")]
     pub async fn new() -> Self {
         let (width, height, os_info, expression_table) = Self::init_common();
-        let query_string = window()
-            .unwrap()
-            .location()
-            .search()
-            .expect("no search exists");
-        let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
-            .await
-            .expect("failed to fetch manifest from remote");
-
+        let manifest = serde_json::from_str(&pax_cartridge::INITIAL_MANIFEST).unwrap();
         let mut definition_to_instance_traverser =
             pax_cartridge::DefinitionToInstanceTraverser::new(manifest);
         let main_component_instance = definition_to_instance_traverser.get_main_component();
         let designtime_manager =
-            definition_to_instance_traverser.get_designtime_manager(query_string);
+            definition_to_instance_traverser.get_designtime_manager("no source url".to_string());
         let engine = pax_runtime::PaxEngine::new_with_designtime(
             main_component_instance,
             expression_table,
@@ -111,7 +103,16 @@ impl PaxChassisWeb {
 
     #[cfg(feature = "designtime")]
     async fn fetch(url: &str) -> Result<PaxManifest, String> {
-        // Fetch the URL
+        // manifest can be fetched using this from Self::new:
+        // let query_string = window()
+        //     .unwrap()
+        //     .location()
+        //     .search()
+        //     .expect("no search exists");
+        // let manifest = Self::fetch(&format!("http://localhost:9000/create/load{query_string}"))
+        //     .await
+        //     .expect("failed to fetch manifest from remote");
+
         let response =
             Into::<wasm_bindgen_futures::JsFuture>::into(window().unwrap().fetch_with_str(url))
                 .await


### PR DESCRIPTION
Load local manifest version instead of from a remote