### PR TITLE
double bindings

### DIFF
--- a/pax-compiler/src/formatting/rules.rs
+++ b/pax-compiler/src/formatting/rules.rs
@@ -144,6 +144,7 @@ fn get_formatting_rules(pest_rule: Rule) -> Vec<Box<dyn FormattingRule>> {
 
         Rule::identifier
         | Rule::pascal_identifier
+        | Rule::double_binding
         | Rule::statement_for_predicate_declaration
         | Rule::statement_for_source
         | Rule::comment

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -13,14 +13,26 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
         let mut properties = {{component.pascal_identifier}}::default();
         {% for property in component.properties %}
             if let Some(vd) = defined_properties.get("{{property.name}}") {
-                properties.{{property.name}}.replace_with(
                     match vd.clone() {
                         ValueDefinition::LiteralValue(lv) => {
                                 let val = from_pax_try_coerce::<{{property.property_type.type_id._type_id}}>(&lv.raw_value)
                                     .map_err(|e| format!("failed to read {}: {}", &lv.raw_value, e)).unwrap();
-                            Property::new_with_name(val, &lv.raw_value)
+                            properties.{{property.name}}.replace_with(Property::new_with_name(val, &lv.raw_value));
                         },
-                        ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token,info) =>
+                        ValueDefinition::Identifier(token,info) => {
+                            let identifier = token.token_value.clone();
+                            let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect("failed to resolve identifier");
+                            let resolved_property : Property<{{property.property_type.type_id._type_id}}> = Property::new_from_untyped(untyped_property.clone());
+                            properties.{{property.name}}.replace_with(Property::computed_with_name(move || {
+                                resolved_property.get()
+                            }, &vec![untyped_property], &token.raw_value));
+                        },
+                        ValueDefinition::DoubleBinding(token,info) => {
+                            let identifier = token.token_value.clone();
+                            let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect("failed to resolve identifier");
+                            properties.{{property.name}} = Property::new_from_untyped(untyped_property.clone());
+                        },
+                        ValueDefinition::Expression(token, info) =>
                         {
                             if let Some(info) = info {
                                 let mut dependents = vec![];
@@ -33,20 +45,22 @@ impl ComponentFactory for {{component.pascal_identifier}}Factory {
                                 }
                                 let cloned_stack = stack_frame.clone();
                                 let cloned_table = table.clone();
-                                Property::computed_with_name(move || {
+                                properties.{{property.name}}.replace_with( Property::computed_with_name(move || {
                                     let new_value_wrapped: PaxAny = cloned_table.compute_vtable_value(&cloned_stack, info.vtable_id.clone());
                                     let coerced = new_value_wrapped.try_coerce::<{{property.property_type.type_id._type_id}}>().unwrap();
                                     coerced
-                                }, &dependents, &token.raw_value)
+                                }, &dependents, &token.raw_value));
                             } else {
                                 unreachable!("No info for expression")
                             }
                         },
                         ValueDefinition::Block(block) => {
-                            Property::new_with_name({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone(), table.clone()), "block")
-                        }
+                            properties.{{property.name}}.replace_with(
+                                Property::new_with_name({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone(), table.clone()), "block")
+                            );
+                            }
                         _ => unreachable!("Invalid value definition for {{property.name}}")
-                    });
+                    }
             }
         {% endfor %}
         properties.to_pax_any()
@@ -155,7 +169,20 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                         let val = from_pax_try_coerce::<{{prop.type_id._type_id}}>(&lv.raw_value).unwrap();
                                         Property::new_with_name(val, &lv.raw_value)
                                     },
-                                    ValueDefinition::Expression(token, info) | ValueDefinition::Identifier(token, info ) =>
+                                    ValueDefinition::Identifier(token,info) => {
+                                        let identifier = token.token_value.clone();
+                                        let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect("failed to resolve identifier");
+                                        let resolved_property : Property<{{prop.type_id._type_id}}> = Property::new_from_untyped(untyped_property.clone());
+                                        Property::computed_with_name(move || {
+                                            resolved_property.get()
+                                        }, &vec![untyped_property], &token.raw_value)
+                                    },
+                                    ValueDefinition::DoubleBinding(token,info) => {
+                                        let identifier = token.token_value.clone();
+                                        let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect("failed to resolve identifier");
+                                        Property::new_from_untyped(untyped_property.clone())
+                                    },
+                                    ValueDefinition::Expression(token, info) =>
                                     {
                                         if let Some(info) = info {
                                             let mut dependents = vec![];

--- a/pax-lang/src/lib.rs
+++ b/pax-lang/src/lib.rs
@@ -27,6 +27,7 @@ fn renamed_rules(rule: &Rule) -> String {
         Rule::event_id => "@HANDLER_NAME".to_string(),
         Rule::attribute_key_value_pair => "setting key-value pair".to_string(),
         Rule::attribute_event_binding => "handler binding".to_string(),
+        Rule::double_binding => "two-way binding".to_string(),
         Rule::any_template_value => "literal value, literal object, expression, identifier".to_string(),
         Rule::id => "id".to_string(),
         Rule::id_binding => "id binding (e.g. id=ID_SELECTOR )".to_string(),

--- a/pax-lang/src/pax.pest
+++ b/pax-lang/src/pax.pest
@@ -45,8 +45,10 @@ pascal_identifier = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHANUMERIC | "_")*}
 event_id = {"@" ~ identifier}
 
 //Describes an attribute k/v pair like `id="some_element"` or `@click=self.handle_click`. Supports expressions.
-attribute_key_value_pair = {attribute_event_binding | id_binding | (identifier ~ "=" ~ any_template_value)}
+attribute_key_value_pair = {double_binding | attribute_event_binding | id_binding | (identifier ~ "=" ~ any_template_value) }
 attribute_event_binding = {event_id ~ "=" ~ literal_function}
+
+double_binding = {"bind:" ~ identifier ~ "=" ~ literal_function}
 
 //`...=5.0`, `...={...}`
 any_template_value = {literal_value | literal_object | expression_wrapped | identifier}

--- a/pax-manifest/src/cartridge_generation/mod.rs
+++ b/pax-manifest/src/cartridge_generation/mod.rs
@@ -175,10 +175,11 @@ impl PaxManifest {
                         ValueDefinition::LiteralValue(_)
                         | ValueDefinition::Block(_)
                         | ValueDefinition::Expression(_, _)
-                        | ValueDefinition::Identifier(_, _) => {
+                        | ValueDefinition::Identifier(_, _)
+                        | ValueDefinition::DoubleBinding(_, _) => {
                             map.insert(key.token_value.clone(), value.clone());
                         }
-                        _ => {}
+                        ValueDefinition::EventBindingTarget(_) | ValueDefinition::Undefined => {}
                     }
                 }
             }

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -1522,6 +1522,8 @@ pub enum ValueDefinition {
     Expression(Token, Option<ExpressionCompilationInfo>),
     /// (Expression contents, vtable id binding)
     Identifier(Token, Option<ExpressionCompilationInfo>),
+    /// (Expression contents, vtable id binding)
+    DoubleBinding(Token, Option<ExpressionCompilationInfo>),
     EventBindingTarget(Token),
 }
 
@@ -1541,6 +1543,9 @@ impl Hash for ValueDefinition {
                 t.hash(state);
             }
             ValueDefinition::Identifier(t, _) => {
+                t.hash(state);
+            }
+            ValueDefinition::DoubleBinding(t, _) => {
                 t.hash(state);
             }
             ValueDefinition::EventBindingTarget(t) => {
@@ -1590,6 +1595,13 @@ impl PartialEq for ValueDefinition {
             }
             ValueDefinition::EventBindingTarget(t) => {
                 if let ValueDefinition::EventBindingTarget(ot) = other {
+                    t == ot
+                } else {
+                    false
+                }
+            }
+            ValueDefinition::DoubleBinding(t, _) => {
+                if let ValueDefinition::DoubleBinding(ot, _) = other {
                     t == ot
                 } else {
                     false

--- a/pax-runtime-api/src/properties/mod.rs
+++ b/pax-runtime-api/src/properties/mod.rs
@@ -55,6 +55,13 @@ impl<T: PropertyValue> Property<T> {
         Self::new_optional_name(val, None)
     }
 
+    pub fn new_from_untyped(untyped: UntypedProperty) -> Self {
+        Self {
+            untyped,
+            _phantom: PhantomData {},
+        }
+    }
+
     pub fn computed(evaluator: impl Fn() -> T + 'static, dependents: &[UntypedProperty]) -> Self {
         Self::computed_with_config(evaluator, dependents, None)
     }


### PR DESCRIPTION
double binding syntax supported: `<Component bind:num_clicks=num_clicks />`

added formatter rules, and migrated identifiers to no longer need expressions.
