### PR TITLE
Let Parent inspect cancelled state during event propagation, stacker behaviour change

### DIFF
--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -55,4 +55,4 @@ lto = true
 codegen-units = 1  
 
 [profile.dev]
-opt-level = 3 
+opt-level = 2

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -17,6 +17,7 @@ use pax_runtime::api::TextboxInput;
 use pax_runtime::api::OS;
 use pax_runtime::ExpressionTable;
 use pax_runtime_api::borrow_mut;
+use pax_runtime_api::Event;
 use web_sys::Response;
 use_RefCell!();
 
@@ -242,7 +243,11 @@ impl PaxChassisWeb {
                         mime_type: args.mime_type.clone(),
                         data,
                     };
-                    topmost_node.dispatch_drop(args_drop, &globals, &engine.runtime_context)
+                    topmost_node.dispatch_drop(
+                        Event::new(args_drop),
+                        &globals,
+                        &engine.runtime_context,
+                    )
                 } else {
                     false
                 }
@@ -295,16 +300,20 @@ impl PaxChassisWeb {
                 let node = engine
                     .get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id))
                     .expect("button node exists in engine");
-                node.dispatch_button_click(ButtonClick {}, &globals, &engine.runtime_context)
+                node.dispatch_button_click(
+                    Event::new(ButtonClick {}),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::FormTextboxInput(args) => {
                 let node = engine
                     .get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id))
                     .expect("textbox node exists in engine");
                 node.dispatch_textbox_input(
-                    TextboxInput {
+                    Event::new(TextboxInput {
                         text: args.text.clone(),
-                    },
+                    }),
                     &globals,
                     &engine.runtime_context,
                 )
@@ -315,9 +324,9 @@ impl PaxChassisWeb {
                     .expect("text node exists in engine");
                 borrow!(node.instance_node).handle_text_change(&node, args.text.clone());
                 node.dispatch_text_input(
-                    TextInput {
+                    Event::new(TextInput {
                         text: args.text.clone(),
-                    },
+                    }),
                     &globals,
                     &engine.runtime_context,
                 )
@@ -327,9 +336,9 @@ impl PaxChassisWeb {
                     .get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id))
                     .expect("textbox node exists in engine");
                 node.dispatch_textbox_change(
-                    TextboxChange {
+                    Event::new(TextboxChange {
                         text: args.text.clone(),
-                    },
+                    }),
                     &globals,
                     &engine.runtime_context,
                 )
@@ -339,9 +348,9 @@ impl PaxChassisWeb {
                     .get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id))
                     .expect("checkbox node exists in engine");
                 node.dispatch_checkbox_change(
-                    CheckboxChange {
+                    Event::new(CheckboxChange {
                         checked: args.state,
-                    },
+                    }),
                     &globals,
                     &engine.runtime_context,
                 )
@@ -365,7 +374,11 @@ impl PaxChassisWeb {
                                 .collect(),
                         },
                     };
-                    topmost_node.dispatch_click(args_click, &globals, &engine.runtime_context)
+                    topmost_node.dispatch_click(
+                        Event::new(args_click),
+                        &globals,
+                        &engine.runtime_context,
+                    )
                 } else {
                     false
                 }
@@ -380,7 +393,11 @@ impl PaxChassisWeb {
                         x: args.x,
                         y: args.y,
                     };
-                    topmost_node.dispatch_clap(args_clap, &globals, &engine.runtime_context)
+                    topmost_node.dispatch_clap(
+                        Event::new(args_clap),
+                        &globals,
+                        &engine.runtime_context,
+                    )
                 } else {
                     false
                 }
@@ -394,7 +411,7 @@ impl PaxChassisWeb {
                     let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
                     let args_touch_start = TouchStart { touches };
                     topmost_node.dispatch_touch_start(
-                        args_touch_start,
+                        Event::new(args_touch_start),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -411,7 +428,7 @@ impl PaxChassisWeb {
                     let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
                     let args_touch_move = TouchMove { touches };
                     topmost_node.dispatch_touch_move(
-                        args_touch_move,
+                        Event::new(args_touch_move),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -428,7 +445,7 @@ impl PaxChassisWeb {
                     let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
                     let args_touch_end = TouchEnd { touches };
                     topmost_node.dispatch_touch_end(
-                        args_touch_end,
+                        Event::new(args_touch_end),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -502,7 +519,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_double_click(
-                        args_double_click,
+                        Event::new(args_double_click),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -528,7 +545,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_mouse_move(
-                        args_mouse_move,
+                        Event::new(args_mouse_move),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -553,7 +570,11 @@ impl PaxChassisWeb {
                         delta_y: args.delta_y,
                         modifiers,
                     };
-                    topmost_node.dispatch_wheel(args_wheel, &globals, &engine.runtime_context)
+                    topmost_node.dispatch_wheel(
+                        Event::new(args_wheel),
+                        &globals,
+                        &engine.runtime_context,
+                    )
                 } else {
                     false
                 }
@@ -576,7 +597,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_mouse_down(
-                        args_mouse_down,
+                        Event::new(args_mouse_down),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -601,7 +622,11 @@ impl PaxChassisWeb {
                                 .collect(),
                         },
                     };
-                    topmost_node.dispatch_mouse_up(args_mouse_up, &globals, &engine.runtime_context)
+                    topmost_node.dispatch_mouse_up(
+                        Event::new(args_mouse_up),
+                        &globals,
+                        &engine.runtime_context,
+                    )
                 } else {
                     false
                 }
@@ -624,7 +649,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_mouse_over(
-                        args_mouse_over,
+                        Event::new(args_mouse_over),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -650,7 +675,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_mouse_out(
-                        args_mouse_out,
+                        Event::new(args_mouse_out),
                         &globals,
                         &engine.runtime_context,
                     )
@@ -676,7 +701,7 @@ impl PaxChassisWeb {
                         },
                     };
                     topmost_node.dispatch_context_menu(
-                        args_context_menu,
+                        Event::new(args_context_menu),
                         &globals,
                         &engine.runtime_context,
                     )

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -127,11 +127,10 @@ macro_rules! dispatch_event_handler {
     ($fn_name:ident, $arg_type:ty, $handler_key:ident, $recurse:expr) => {
         pub fn $fn_name(
             &self,
-            args: $arg_type,
+            event: Event<$arg_type>,
             globals: &Globals,
             ctx: &Rc<RuntimeContext>,
         ) -> bool {
-            let event = Event::new(args.clone());
             if let Some(registry) = borrow!(self.instance_node).base().get_handler_registry() {
                 let borrowed_registry = &borrow!(*registry);
                 if let Some(handlers) = borrowed_registry.handlers.get($handler_key) {
@@ -162,8 +161,7 @@ macro_rules! dispatch_event_handler {
 
             if $recurse {
                 if let Some(parent) = self.template_parent.upgrade() {
-                    let parent_prevent_default = parent.$fn_name(args, globals, ctx);
-                    return event.cancelled() || parent_prevent_default;
+                    return parent.$fn_name(event, globals, ctx);
                 }
             }
             event.cancelled()

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -8,7 +8,7 @@ use kurbo::Affine;
 use pax_manifest::UniqueTemplateNodeIdentifier;
 use pax_message::{NativeMessage, OcclusionPatch};
 use pax_runtime_api::{
-    borrow, borrow_mut, math::Transform2, pax_value::PaxAny, use_RefCell, Window, OS,
+    borrow, borrow_mut, math::Transform2, pax_value::PaxAny, use_RefCell, Event, Window, OS,
 };
 
 use crate::api::{KeyDown, KeyPress, KeyUp, Layer, NodeContext, OcclusionLayerGen, RenderContext};
@@ -470,7 +470,7 @@ impl PaxEngine {
         self.root_node
             .recurse_visit_postorder(&mut |expanded_node| {
                 expanded_node.dispatch_key_down(
-                    args.clone(),
+                    Event::new(args.clone()),
                     &self.runtime_context.globals(),
                     &self.runtime_context,
                 );
@@ -481,7 +481,7 @@ impl PaxEngine {
         self.root_node
             .recurse_visit_postorder(&mut |expanded_node| {
                 expanded_node.dispatch_key_up(
-                    args.clone(),
+                    Event::new(args.clone()),
                     &self.runtime_context.globals(),
                     &self.runtime_context,
                 );
@@ -492,7 +492,7 @@ impl PaxEngine {
         self.root_node
             .recurse_visit_postorder(&mut |expanded_node| {
                 expanded_node.dispatch_key_press(
-                    args.clone(),
+                    Event::new(args.clone()),
                     &self.runtime_context.globals(),
                     &self.runtime_context,
                 );

--- a/pax-std/src/stacker.rs
+++ b/pax-std/src/stacker.rs
@@ -84,22 +84,22 @@ impl Stacker {
                 };
 
                 let usable_interior_space = active_bound - (cells - 1.0) * gutter_calc.to_float();
-
                 let per_cell_space = usable_interior_space / cells;
 
                 let mut cell_space = vec![per_cell_space; cells as usize];
-                let sizes = sizes.get();
+                let mut sizes = sizes.get();
+                while sizes.len() < cell_space.len() {
+                    if sizes.contains(&None) {
+                        sizes.push(None)
+                    } else {
+                        sizes.push(Some(Size::Percent((100.0 / cells).into())))
+                    }
+                }
 
                 if sizes.len() > 0 {
-                    if sizes.len() != (cells as usize) {
-                        unreachable!(
-                            "Sizes is not a valid length. Please specify {} sizes",
-                            (cells as usize)
-                        );
-                    }
                     let mut used_space = 0.0;
                     let mut remaining_cells = 0.0;
-                    for (i, size) in sizes.iter().enumerate() {
+                    for (i, size) in sizes.iter().take(cells as usize).enumerate() {
                         if let Some(s) = size {
                             let space = match s {
                                 Size::Pixels(pix) => *pix,
@@ -118,12 +118,6 @@ impl Stacker {
                             cell_space[i] = -1.0;
                             remaining_cells += 1.0;
                         }
-                    }
-                    if used_space > usable_interior_space {
-                        unreachable!(
-                            "Invalid sizes. Usable interior space is {}px",
-                            usable_interior_space
-                        );
                     }
 
                     let remaining_per_cell_space =


### PR DESCRIPTION
Events higher up the event hierarchy can now inspect the event.cancelled state. 

Stacker now tries to handle any case of cells.len() != sizes.len() gracefully.