### PR TITLE
QA Fixes + Fix for recursive properties error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Cargo.lock
 ## VScode project configuration files
 .vscode/
 
+pax-chassis-web/interface/
+pax-chassis-web/interface/

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -40,7 +40,6 @@ use serde_json;
 #[cfg(feature = "designtime")]
 use {pax_designtime::orm::ReloadType, pax_designtime::DesigntimeManager};
 
-#[cfg(feature = "designtime")]
 const USERLAND_COMPONENT_ROOT: &str = "USERLAND_COMPONENT_ROOT";
 #[cfg(feature = "designtime")]
 const DESIGNER_COMPONENT_ROOT: &str = "DESIGNER_COMPONENT_ROOT";
@@ -116,7 +115,8 @@ impl PaxChassisWeb {
     ) -> Self {
         let (width, height, os_info) = Self::init_common();
 
-        let main_component_instance = definition_to_instance_traverser.get_main_component();
+        let main_component_instance =
+            definition_to_instance_traverser.get_main_component(USERLAND_COMPONENT_ROOT);
         let engine = pax_runtime::PaxEngine::new(
             main_component_instance,
             (width, height),

--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -76,9 +76,7 @@ impl pax_engine::pax_runtime::ComponentFactory for {{component.pascal_identifier
                                 },
                                 pax_engine::pax_manifest::ValueDefinition::Block(block) => {
                                     let cloned_stack = stack_frame.clone();
-                                    properties.{{property.name}}.replace_with(
-                                        Property::new_with_name({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, cloned_stack.clone()), "block")
-                                    );
+                                    properties.{{property.name}}.replace_with({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, cloned_stack.clone()));
                                 }
                                 _ => unreachable!("Invalid value definition for {{property.name}}")
                             }
@@ -174,10 +172,11 @@ struct {{active_type.type_id._type_id_escaped}}TypeFactory{}
 
 impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
 
-    type Output={{active_type.type_id._type_id}};
+    type Output=Property<{{active_type.type_id._type_id}}>;
 
     fn build_type(&self, args: &pax_engine::pax_manifest::LiteralBlockDefinition, stack_frame: std::rc::Rc<pax_engine::pax_runtime::RuntimePropertiesStackFrame>) -> Self::Output {
         let mut properties: {{active_type.type_id._type_id}} = Default::default();
+        let mut deps = vec![];
         for setting in &args.elements {
             if let pax_engine::pax_manifest::SettingElement::Setting(k, vd) = setting {
                 match k.token_value.as_str() {
@@ -194,7 +193,9 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                     pax_engine::pax_manifest::ValueDefinition::DoubleBinding(identifier) => {
                                         let identifier = identifier.name.clone();
                                         let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect(&format!("failed to resolve identifier: {}", &identifier));
-                                        Property::new_from_untyped(untyped_property.clone())
+                                        let ret = Property::new_from_untyped(untyped_property.clone());
+                                        deps.push(ret.untyped());
+                                        ret
                                     },
                                     pax_engine::pax_manifest::ValueDefinition::Identifier(ident)  => {
                                         let variable = if let Some(p) = stack_frame.resolve_symbol_as_variable(&ident.name) {
@@ -205,14 +206,16 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                         let name = ident.name.clone();
                                         let untyped = variable.get_untyped_property().clone();
                                         let cloned_variable = variable.clone();
-                                        Property::computed_with_name(
+                                        let ret = Property::computed_with_name(
                                             move || {
                                                 let new_value = cloned_variable.get_as_pax_value();
                                                 <{{prop.type_id._type_id}}>::try_coerce(new_value).unwrap()
                                             },
                                             &[untyped],
                                             &name,
-                                        )
+                                        );
+                                        deps.push(ret.untyped());
+                                        ret
                                     }
                                     pax_engine::pax_manifest::ValueDefinition::Expression(info) =>
                                     {
@@ -226,7 +229,7 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                         }
                                         let cloned_stack = stack_frame.clone();
                                         let cloned_ast = info.expression.clone();
-                                        Property::computed_with_name(
+                                        let ret = Property::computed_with_name(
                                             move || {
                                                 let new_value = cloned_ast
                                                     .compute(cloned_stack.clone())
@@ -244,10 +247,14 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                             },
                                             &dependents,
                                             "{{prop.name}}",
-                                        )
+                                        );
+                                        deps.push(ret.untyped());
+                                        ret
                                     },
                                     pax_engine::pax_manifest::ValueDefinition::Block(block) => {
-                                        Property::new_with_name({{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone()), "block")
+                                        let ret = {{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, stack_frame.clone());
+                                        deps.push(ret.untyped());
+                                        ret
                                     }
                                     _ => unreachable!("Invalid value definition for {{prop.name}}")
                                 };
@@ -256,9 +263,6 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
                                     pax_engine::pax_manifest::ValueDefinition::LiteralValue(lv) => {
                                         <{{prop.type_id._type_id}}>::try_coerce(lv.clone()).unwrap()
                                     },
-                                    pax_engine::pax_manifest::ValueDefinition::Block(block) => {
-                                        {{prop.type_id._type_id_escaped}}TypeFactory{}.build_type(args, stack_frame.clone())
-                                    }
                                     _ => unreachable!("Invalid value definition for {{prop.name}}")
                                 };
                             {% endif %}
@@ -270,7 +274,19 @@ impl TypeFactory for {{active_type.type_id._type_id_escaped}}TypeFactory {
             
             }
         }
-        properties
+        Property::computed_with_name(
+            move || {
+                let cloned_prop = properties.clone();
+                {%- for prop in active_type.property_definitions -%}
+                    {%- if prop.flags.is_property_wrapped %}
+                    cloned_prop.{{prop.name}}.get();
+                    {%- endif -%}
+                {%- endfor %}
+                cloned_prop
+            },
+            &deps,
+            "computed"
+        )
     }
 }
 

--- a/pax-compiler/templates/code_serialization/macros.tera
+++ b/pax-compiler/templates/code_serialization/macros.tera
@@ -36,7 +36,7 @@
         bind:{{ vd.DoubleBinding.name }}
     {% endif %}
     {% if vd.EventBindingTarget %}
-        {{ vd.EventBindingTarget.token_value }}
+        {{ vd.EventBindingTarget.name }}
     {% endif %}
 {% endmacro %}
 

--- a/pax-designer/src/controls/settings/property_editor/mod.rs
+++ b/pax-designer/src/controls/settings/property_editor/mod.rs
@@ -110,10 +110,11 @@ impl PropertyEditor {
         let is_literal = self.is_literal.clone();
         let deps = [is_literal.untyped()];
         self.fx_text_color.replace_with(Property::computed(
-            move || match is_literal.get() {
+            move || {
+                match is_literal.get() {
                 true => Color::WHITE,
                 false => Color::rgb(207.into(), 31.into(), 201.into()),
-            },
+            }},
             &deps,
         ));
         let is_literal = self.is_literal.clone();

--- a/pax-lang/src/interpreter/property_resolution.rs
+++ b/pax-lang/src/interpreter/property_resolution.rs
@@ -34,11 +34,7 @@ impl DependencyCollector for PaxPrimary {
             PaxPrimary::FunctionCall(f) => f.collect_dependencies(),
             PaxPrimary::Object(o) => o
                 .iter()
-                .flat_map(|(k, v)| {
-                    let mut deps = v.collect_dependencies();
-                    deps.push(k.clone());
-                    deps
-                })
+                .flat_map(|(_, v)| v.collect_dependencies())
                 .collect(),
             PaxPrimary::Enum(_, args) => {
                 args.iter().flat_map(|a| a.collect_dependencies()).collect()

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -895,6 +895,18 @@ impl Interpolatable for i64 {
     }
 }
 
+impl Interpolatable for i128 {
+    fn interpolate(&self, other: &i128, t: f64) -> i128 {
+        (*self as f64 + (*other - self) as f64 * t) as i128
+    }
+}
+
+impl Interpolatable for u128 {
+    fn interpolate(&self, other: &u128, t: f64) -> u128 {
+        (*self as f64 + (*other - self) as f64 * t) as u128
+    }
+}
+
 impl Interpolatable for u64 {
     fn interpolate(&self, other: &u64, t: f64) -> u64 {
         (*self as f64 + (*other - self) as f64 * t) as u64

--- a/pax-runtime-api/src/pax_value/arithmetic.rs
+++ b/pax-runtime-api/src/pax_value/arithmetic.rs
@@ -30,6 +30,12 @@ impl Add for PaxValue {
             | (PaxValue::Numeric(b), PaxValue::Bool(a)) => {
                 (Numeric::I64(a as i64) + b).to_pax_value()
             }
+            (PaxValue::Size(a), PaxValue::Numeric(b))
+            | (PaxValue::Numeric(b), PaxValue::Size(a)) => match a {
+                Size::Pixels(px) => Size::Pixels(px + b).to_pax_value(),
+                Size::Percent(per) => Size::Percent(per + b).to_pax_value(),
+                Size::Combined(px, per) => Size::Combined(px + b, per + b).to_pax_value(),
+            },
             (a, b) => panic!("can't add {:?} and {:?}", a, b),
         }
     }
@@ -45,6 +51,12 @@ impl Mul for PaxValue {
             | (PaxValue::Numeric(b), PaxValue::Bool(a)) => {
                 (Numeric::I64(a as i64) * b).to_pax_value()
             }
+            (PaxValue::Size(a), PaxValue::Numeric(b))
+            | (PaxValue::Numeric(b), PaxValue::Size(a)) => match a {
+                Size::Pixels(px) => Size::Pixels(px * b).to_pax_value(),
+                Size::Percent(per) => Size::Percent(per * b).to_pax_value(),
+                Size::Combined(px, per) => Size::Combined(px * b, per * b).to_pax_value(),
+            },
             (a, b) => panic!("can't multiply {:?} and {:?}", a, b),
         }
     }
@@ -61,6 +73,12 @@ impl Sub for PaxValue {
             (PaxValue::Percent(a), PaxValue::Percent(b)) => (Percent(a.0 - b.0)).to_pax_value(),
             (PaxValue::Percent(a), PaxValue::Size(b)) => (Size::Percent(a.0) - b).to_pax_value(),
             (PaxValue::Size(a), PaxValue::Percent(b)) => (a - Size::Percent(b.0)).to_pax_value(),
+            (PaxValue::Size(a), PaxValue::Numeric(b))
+            | (PaxValue::Numeric(b), PaxValue::Size(a)) => match a {
+                Size::Pixels(px) => Size::Pixels(px - b).to_pax_value(),
+                Size::Percent(per) => Size::Percent(per - b).to_pax_value(),
+                Size::Combined(px, per) => Size::Combined(px - b, per - b).to_pax_value(),
+            },
             (a, b) => panic!("can't subtract {:?} and {:?}", a, b),
         }
     }
@@ -72,6 +90,12 @@ impl Div for PaxValue {
     fn div(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (PaxValue::Numeric(a), PaxValue::Numeric(b)) => (a / b).to_pax_value(),
+            (PaxValue::Size(a), PaxValue::Numeric(b))
+            | (PaxValue::Numeric(b), PaxValue::Size(a)) => match a {
+                Size::Pixels(px) => Size::Pixels(px / b).to_pax_value(),
+                Size::Percent(per) => Size::Percent(per / b).to_pax_value(),
+                Size::Combined(px, per) => Size::Combined(px / b, per / b).to_pax_value(),
+            },
             (a, b) => panic!("can't divide {:?} and {:?}", a, b),
         }
     }


### PR DESCRIPTION
This should resolve:
- https://linear.app/paxdev/issue/PAX-589/expressions-in-blocks-not-adding-deps
- https://linear.app/paxdev/issue/PAX-608/post-designer-qa-warfa
- https://linear.app/paxdev/issue/PAX-610/enable-objects-as-top-level-expression-values


**Context for https://linear.app/paxdev/issue/PAX-589/expressions-in-blocks-not-adding-deps:** 
It turns out we never call get for properties within properties that are used in Native Elements. 

For example [here](https://github.com/paxengine/pax/blob/1521b6efb54d600186747dadcdc895bf725df254/pax-std/src/core/text.rs#L153). We setup dependencies between native_message_props and the top level properties in the Text struct. However there is no link between the properties within TextStyle and native_message_props. Thus when a property like font_size is dirtied, nothing happens because get is never called. 

I fixed this by rewriting the recursive block code-gen to return a Property::computed that depends on and calls get on all properties within it.

**Context for: https://linear.app/paxdev/issue/PAX-610/enable-objects-as-top-level-expression-values**
Keys in were accidentally being added to the dependency list for Objects in PaxExpression collect dependencies. It was parsing correctly, it just would then fail at runtime to resolve those properties since they were just key names. 

Some small additional cleanup