### PR TITLE
Occlusion calc update

### DIFF
--- a/.helix/config.toml
+++ b/.helix/config.toml
@@ -1,3 +1,1 @@
-# [editor]
-# workspace-lsp-roots = [".", "pax-designer", "pax", "designer-project", "pax/examples/src/ui-components"]
 

--- a/examples/src/increment/Cargo.toml
+++ b/examples/src/increment/Cargo.toml
@@ -20,6 +20,9 @@ required-features = ["parser"]
 name = "run"
 path = "bin/run.rs"
 
+[profile.dev]
+opt-level = 2
+
 [features]
 designer = ["pax-kit/designer"]
 parser = ["pax-kit/parser"]

--- a/pax-compiler/files/interfaces/web/src/classes/native-element-pool.ts
+++ b/pax-compiler/files/interfaces/web/src/classes/native-element-pool.ts
@@ -81,7 +81,12 @@ export class NativeElementPool {
     occlusionUpdate(patch: OcclusionUpdatePatch) {
         let node: HTMLElement = this.nodesLookup.get(patch.id!)!;
         if (node){
+            // scroll resets when moved, avoid this.
+            let left = node.scrollLeft;
+            let top = node.scrollTop;
             this.layers.addElement(node, patch.parentFrame, patch.occlusionLayerId!);
+            node.scrollLeft = left;
+            node.scrollTop = top;
             node.style.zIndex = patch.zIndex!.toString();
             const focusableElements = node.querySelectorAll('input, button, select, textarea, a[href]');
             focusableElements.forEach((element, _index) => {

--- a/pax-compiler/files/interfaces/web/src/index.ts
+++ b/pax-compiler/files/interfaces/web/src/index.ts
@@ -128,7 +128,10 @@ function renderLoop (chassis: PaxChassisWeb, mount: Element, get_latest_memory: 
 
 export function processMessages(messages: any[], chassis: PaxChassisWeb, objectManager: ObjectManager) {
     messages?.forEach((unwrapped_msg) => {
-        if(unwrapped_msg["OcclusionUpdate"]) {
+        if(unwrapped_msg["ShrinkLayersTo"]) {
+            let layers_needed = unwrapped_msg["ShrinkLayersTo"];
+            nativePool.layers.shrinkTo(layers_needed);
+        } else if(unwrapped_msg["OcclusionUpdate"]) {
             let msg = unwrapped_msg["OcclusionUpdate"]
             let patch: OcclusionUpdatePatch = objectManager.getFromPool(OCCLUSION_UPDATE_PATCH);
             patch.fromPatch(msg);

--- a/pax-designer/src/controls/settings/property_editor/text_style_property_editor.pax
+++ b/pax-designer/src/controls/settings/property_editor/text_style_property_editor.pax
@@ -69,7 +69,6 @@
     }
 
     .input {
-        width: 96.66%,
         height: 30px,
         background: BLACK,
         stroke: {

--- a/pax-designer/src/controls/toolbar/mod.rs
+++ b/pax-designer/src/controls/toolbar/mod.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 pub mod toolbar_item;
 use crate::llm_interface::OpenLLMPrompt;
 use crate::math::coordinate_spaces::Glass;
+use crate::math::SizeUnit;
 use crate::model::action::{Action, ActionContext};
 use crate::model::{self, Component, ProjectMode, Tool, ToolBehavior};
 use crate::ProjectMsg;
@@ -275,6 +276,13 @@ pub struct SelectTool {
 
 impl Action for SelectTool {
     fn perform(&self, ctx: &mut model::action::ActionContext) -> Result<()> {
+        // set px/percent mode if a new pointer tool is selected,
+        // is there some better way of persisting this? (tool stack?)
+        match self.tool {
+            Tool::PointerPercent => ctx.app_state.unit_mode.set(SizeUnit::Percent),
+            Tool::PointerPixels => ctx.app_state.unit_mode.set(SizeUnit::Pixels),
+            _ => (),
+        }
         ctx.app_state.selected_tool.set(self.tool);
         Ok(())
     }

--- a/pax-designer/src/controls/tree/mod.rs
+++ b/pax-designer/src/controls/tree/mod.rs
@@ -81,6 +81,8 @@ enum Desc {
     Image,
     Slider,
     Dropdown,
+    If,
+    For,
 }
 
 impl Desc {
@@ -101,6 +103,8 @@ impl Desc {
             Desc::Image => ("Image", "13-image", false),
             Desc::Slider => ("Slider", "14-slider", false),
             Desc::Dropdown => ("Dropdown", "15-dropdown", false),
+            Desc::If => ("If", "08-component", true),
+            Desc::For => ("For", "08-component", true),
         };
         (
             name.to_owned(),
@@ -149,29 +153,6 @@ pub struct FlattenedTreeEntry {
 }
 
 impl Tree {
-    // TODO re-implement tree collapsing. Do collapsed state as separate prop
-    // that visible_tree_objects can listen to, and that is updated by changes
-    // in click_msg
-    // TreeMsg::ArrowClicked(sender) => {
-    //     tree[sender].is_collapsed = !tree[sender].is_collapsed;
-    //     let collapsed = tree[sender].is_collapsed;
-    //     for i in (sender + 1)..tree.len() {
-    //         if tree[sender].indent_level < tree[i].indent_level {
-    //             tree[i].is_visible = !collapsed;
-    //             tree[i].is_collapsed = collapsed;
-    //         } else {
-    //             break;
-    //         }
-    //     }
-    //     self.visible_tree_objects.set(
-    //         self.tree_objects
-    //             .get()
-    //             .iter()
-    //             .filter(|o| o.is_visible)
-    //             .cloned()
-    //             .collect(),
-    //     );
-    // }
     pub fn on_mount(&mut self, ctx: &NodeContext) {
         model::read_app_state(|app_state| {
             let type_id = app_state.selected_component_id.clone();
@@ -436,24 +417,30 @@ fn to_tree(tnid: &TemplateNodeId, component_template: &ComponentTemplate) -> Opt
 }
 
 fn resolve_tree_type(type_id: TypeId) -> Desc {
-    let Some(import_path) = type_id.import_path() else {
-        return Desc::Component(format!("{}", type_id.get_pax_type()));
-    };
-    match import_path.trim_start_matches("pax_std::") {
-        "core::group::Group" => Desc::Group,
-        "core::frame::Frame" => Desc::Frame,
-        "drawing::ellipse::Ellipse" => Desc::Ellipse,
-        "core::text::Text" => Desc::Text,
-        "layout::stacker::Stacker" => Desc::Stacker,
-        "drawing::rectangle::Rectangle" => Desc::Rectangle,
-        "drawing::path::Path" => Desc::Path,
-        "forms::textbox::Textbox" => Desc::Textbox,
-        "forms::checkbox::Checkbox" => Desc::Checkbox,
-        "core::scroller::Scroller" => Desc::Scroller,
-        "forms::button::Button" => Desc::Button,
-        "core::image::Image" => Desc::Image,
-        "forms::slider::Slider" => Desc::Slider,
-        "forms::dropdown::Dropdown" => Desc::Dropdown,
-        _ => Desc::Component(format!("{}", type_id.get_pax_type())),
+    match type_id.get_pax_type() {
+        PaxType::If => Desc::If,
+        PaxType::Repeat => Desc::For,
+        _ => {
+            let Some(import_path) = type_id.import_path() else {
+                return Desc::Component(format!("{}", type_id.get_pax_type()));
+            };
+            match import_path.trim_start_matches("pax_std::") {
+                "core::group::Group" => Desc::Group,
+                "core::frame::Frame" => Desc::Frame,
+                "drawing::ellipse::Ellipse" => Desc::Ellipse,
+                "core::text::Text" => Desc::Text,
+                "layout::stacker::Stacker" => Desc::Stacker,
+                "drawing::rectangle::Rectangle" => Desc::Rectangle,
+                "drawing::path::Path" => Desc::Path,
+                "forms::textbox::Textbox" => Desc::Textbox,
+                "forms::checkbox::Checkbox" => Desc::Checkbox,
+                "core::scroller::Scroller" => Desc::Scroller,
+                "forms::button::Button" => Desc::Button,
+                "core::image::Image" => Desc::Image,
+                "forms::slider::Slider" => Desc::Slider,
+                "forms::dropdown::Dropdown" => Desc::Dropdown,
+                _ => Desc::Component(format!("{}", type_id.get_pax_type())),
+            }
+        }
     }
 }

--- a/pax-designer/src/model/action/pointer.rs
+++ b/pax-designer/src/model/action/pointer.rs
@@ -11,7 +11,7 @@ use crate::model::tools::{CreateComponentTool, MovingTool, MultiSelectTool};
 use crate::model::Component;
 use crate::model::{action, Tool};
 use crate::model::{AppState, StageInfo};
-use crate::{SetStage};
+use crate::SetStage;
 use anyhow::{anyhow, Result};
 use pax_designtime::DesigntimeManager;
 use pax_engine::api::{borrow, Color, MouseButton, Window};
@@ -62,11 +62,6 @@ impl Action for MouseEntryPointAction<'_> {
                 (MouseButton::Left, false) => match ctx.app_state.selected_tool.get() {
                     mode @ (Tool::PointerPercent | Tool::PointerPixels) => {
                         (self.prevent_default)();
-                        ctx.app_state.unit_mode.set(match mode {
-                            Tool::PointerPercent => SizeUnit::Percent,
-                            Tool::PointerPixels => SizeUnit::Pixels,
-                            _ => unreachable!("matched on above"),
-                        });
                         if let Some(hit) = ctx.raycast_glass(point_glass, RaycastMode::Top, &[]) {
                             tool_behavior.set(Some(Rc::new(RefCell::new(MovingTool::new(
                                 ctx,

--- a/pax-designer/src/model/tools.rs
+++ b/pax-designer/src/model/tools.rs
@@ -21,7 +21,7 @@ use crate::math::{
 use crate::model::action::orm::{MoveNode, NodeLayoutSettings};
 use crate::model::Tool;
 use crate::model::{AppState, ToolBehavior};
-use crate::{SetStage};
+use crate::SetStage;
 use anyhow::{anyhow, Result};
 use pax_designtime::DesigntimeManager;
 use pax_engine::api::math::Transform2;
@@ -447,10 +447,7 @@ impl ToolBehavior for MovingTool {
             .transform_and_bounds
             .get()
             .contains_point(point)
-            && ctx
-                .engine_context
-                .get_userland_root_expanded_node()
-                != curr_slot
+            && ctx.engine_context.get_userland_root_expanded_node() != curr_slot
         {
             let container_parent = curr_node
                 .raw_node_interface
@@ -562,9 +559,7 @@ impl ToolBehavior for MultiSelectTool {
 
     fn pointer_move(&mut self, point: Point2<Glass>, ctx: &mut ActionContext) -> ControlFlow<()> {
         self.bounds.set(AxisAlignedBox::new(self.p1, point));
-        let project_root = ctx
-            .engine_context
-            .get_userland_root_expanded_node();
+        let project_root = ctx.engine_context.get_userland_root_expanded_node();
         let selection_box = TransformAndBounds {
             transform: self.bounds.get().as_transform(),
             bounds: (1.0, 1.0),

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -45,6 +45,7 @@ pub enum NativeMessage {
     ScrollerDelete(u32),
     ImageLoad(ImagePatch),
     LayerAdd(LayerAddPatch), //FUTURE: native form controls
+    ShrinkLayersTo(u32),
     OcclusionUpdate(OcclusionPatch),
     Navigate(NavigationPatch),
 }

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -960,58 +960,8 @@ pub struct Timeline {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Layer {
     Native,
-    Scroller,
     Canvas,
     DontCare,
-}
-
-/// Captures information about z-index during render node traversal
-/// Used for generating chassis side rendering architecture
-#[derive(Debug, Clone)]
-pub struct OcclusionLayerGen {
-    canvas_index: u32,
-    layer: Layer,
-    #[allow(dead_code)]
-    parent_scroller: Option<Vec<u32>>,
-}
-
-impl OcclusionLayerGen {
-    pub fn new(scroller_id: Option<Vec<u32>>) -> Self {
-        OcclusionLayerGen {
-            canvas_index: 0,
-            layer: Layer::Canvas,
-            parent_scroller: scroller_id,
-        }
-    }
-
-    pub fn get_level(&mut self) -> u32 {
-        self.canvas_index
-    }
-
-    pub fn get_current_layer(&mut self) -> Layer {
-        self.layer.clone()
-    }
-    pub fn update_z_index(&mut self, layer: Layer) {
-        match layer {
-            Layer::DontCare => {}
-            _ => {
-                if self.layer != layer {
-                    if layer == Layer::Canvas || layer == Layer::Scroller {
-                        self.canvas_index += 1;
-                    }
-                }
-                self.layer = layer.clone();
-            }
-        }
-    }
-
-    pub fn assemble_canvas_id(scroller_id: Option<Vec<u32>>, z_index: u32) -> String {
-        if let Some(id) = scroller_id {
-            format!("{:?}_{}", id, z_index)
-        } else {
-            format!("{}", z_index)
-        }
-    }
 }
 
 /// Raw Percent type, which we use for serialization and dynamic traversal.  At the time

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -138,7 +138,9 @@ impl<R: piet::RenderContext> Renderer<R> {
 
 impl<R: piet::RenderContext> crate::api::RenderContext for Renderer<R> {
     fn fill(&mut self, layer: &str, path: kurbo::BezPath, brush: &piet_common::PaintBrush) {
-        self.backends.get_mut(layer).unwrap().fill(path, brush);
+        if let Some(layer) = self.backends.get_mut(layer) {
+            layer.fill(path, brush);
+        }
     }
 
     fn stroke(
@@ -148,34 +150,33 @@ impl<R: piet::RenderContext> crate::api::RenderContext for Renderer<R> {
         brush: &piet_common::PaintBrush,
         width: f64,
     ) {
-        self.backends
-            .get_mut(layer)
-            .unwrap()
-            .stroke(path, brush, width);
+        if let Some(layer) = self.backends.get_mut(layer) {
+            layer.stroke(path, brush, width);
+        }
     }
 
     fn save(&mut self, layer: &str) {
-        self.backends
-            .get_mut(layer)
-            .unwrap()
-            .save()
-            .expect("failed to save piet state");
+        if let Some(layer) = self.backends.get_mut(layer) {
+            let _ = layer.save();
+        }
     }
 
     fn transform(&mut self, layer: &str, affine: Affine) {
-        self.backends.get_mut(layer).unwrap().transform(affine);
+        if let Some(layer) = self.backends.get_mut(layer) {
+            layer.transform(affine);
+        }
     }
 
     fn clip(&mut self, layer: &str, path: kurbo::BezPath) {
-        self.backends.get_mut(layer).unwrap().clip(path);
+        if let Some(layer) = self.backends.get_mut(layer) {
+            layer.clip(path);
+        }
     }
 
     fn restore(&mut self, layer: &str) {
-        self.backends
-            .get_mut(layer)
-            .unwrap()
-            .restore()
-            .expect("failed to restore piet state");
+        if let Some(layer) = self.backends.get_mut(layer) {
+            let _ = layer.restore();
+        }
     }
 
     fn load_image(&mut self, path: &str, buf: &[u8], width: usize, height: usize) {
@@ -201,11 +202,9 @@ impl<R: piet::RenderContext> crate::api::RenderContext for Renderer<R> {
         let Some(data) = self.image_map.get(image_path) else {
             return;
         };
-        self.backends.get_mut(layer).unwrap().draw_image(
-            &data.img,
-            rect,
-            InterpolationMode::Bilinear,
-        );
+        if let Some(layer) = self.backends.get_mut(layer) {
+            layer.draw_image(&data.img, rect, InterpolationMode::Bilinear);
+        }
     }
 
     fn layers(&self) -> Vec<&str> {

--- a/pax-runtime/src/engine/occlusion.rs
+++ b/pax-runtime/src/engine/occlusion.rs
@@ -1,0 +1,217 @@
+use std::{
+    rc::Rc,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use pax_message::{borrow, OcclusionPatch};
+use pax_runtime_api::{Layer, Window};
+
+use crate::{node_interface::NodeLocal, ExpandedNode, RuntimeContext, TransformAndBounds};
+
+use super::expanded_node::Occlusion;
+
+static DEBUG_ON: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug)]
+pub struct OcclusionBox {
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+}
+
+impl OcclusionBox {
+    fn intersects(&self, other: &Self) -> bool {
+        if self.x2 < other.x1 || other.x2 < self.x1 {
+            return false;
+        }
+        if self.y2 < other.y1 || other.y2 < self.y1 {
+            return false;
+        }
+        true
+    }
+
+    fn union(self, other: Self) -> Self {
+        Self {
+            x1: self.x1.min(other.x1),
+            y1: self.y1.min(other.y1),
+            x2: self.x2.max(other.x2),
+            y2: self.y2.max(other.y2),
+        }
+    }
+
+    fn new_from_transform_and_bounds(t_and_b: TransformAndBounds<NodeLocal, Window>) -> Self {
+        let corners = t_and_b.corners();
+        let mut x2 = f64::MIN;
+        let mut y2 = f64::MIN;
+        let mut x1 = f64::MAX;
+        let mut y1 = f64::MAX;
+        for c in corners {
+            x2 = x2.max(c.x);
+            y2 = y2.max(c.y);
+            x1 = x1.min(c.x);
+            y1 = y1.min(c.y);
+        }
+        OcclusionBox { x1, y1, x2, y2 }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct OcclusionSet {
+    bounds_native: Option<OcclusionBox>,
+    bounds_canvas: Option<OcclusionBox>,
+    pub layers_needed: u32,
+}
+
+struct NodeOcclusionData {
+    occlusion_set: OcclusionSet,
+    node: Rc<ExpandedNode>,
+    children: Vec<(NodeOcclusionData, u32)>,
+}
+
+impl std::fmt::Debug for NodeOcclusionData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("N")
+            .field("s", &self.occlusion_set.layers_needed)
+            .field("c", &self.children)
+            .finish()
+    }
+}
+
+impl OcclusionSet {
+    fn merge_above(&mut self, above: &Self) -> u32 {
+        if DEBUG_ON.load(Ordering::Relaxed) {
+            log::debug!("Merging: {:?}, {:?}", self, above);
+        }
+        let mut layers_needed = self.layers_needed.max(above.layers_needed);
+        let mut above_draw_container_offset = self.layers_needed;
+        if let (Some(below_native), Some(above_canvas)) = (self.bounds_native, above.bounds_canvas)
+        {
+            if DEBUG_ON.load(Ordering::Relaxed) {
+                log::debug!("merge_above: bellow native, above canvas");
+            }
+            if below_native.intersects(&above_canvas) {
+                layers_needed = self.layers_needed + above.layers_needed + 1;
+                above_draw_container_offset = self.layers_needed + 1;
+            }
+        }
+        let bounds_native = match (self.bounds_native, above.bounds_native) {
+            (None, None) => None,
+            (Some(o), None) | (None, Some(o)) => Some(o),
+            (Some(a), Some(b)) => Some(a.union(b)),
+        };
+        let bounds_canvas = match (self.bounds_canvas, above.bounds_canvas) {
+            (None, None) => None,
+            (Some(o), None) | (None, Some(o)) => Some(o),
+            (Some(a), Some(b)) => Some(a.union(b)),
+        };
+        if DEBUG_ON.load(Ordering::Relaxed) {
+            log::debug!("merge done");
+        }
+        *self = Self {
+            bounds_native,
+            bounds_canvas,
+            layers_needed,
+        };
+        above_draw_container_offset
+    }
+}
+
+pub fn update_node_occlusion(root_node: &Rc<ExpandedNode>, ctx: &RuntimeContext) {
+    #[cfg(feature = "designtime")]
+    {
+        let usr_node = borrow!(ctx.userland_root_expanded_node);
+        if let Some(node) = &*usr_node {
+            // DEBUG_ON.store(true, Ordering::Relaxed);
+            let dummy_data = calculate_occlusion_data(&node);
+            // DEBUG_ON.store(false, Ordering::Relaxed);
+            log::debug!("tree: {:#?}", dummy_data);
+        }
+    }
+    let occlusion_data = calculate_occlusion_data(&root_node);
+    let mut z_index = 0;
+    update_node_occlusion_recursive(occlusion_data, ctx, 0, false, &mut z_index);
+}
+
+fn update_node_occlusion_recursive(
+    occlusion_data: NodeOcclusionData,
+    ctx: &RuntimeContext,
+    layer_offset: u32,
+    clipping: bool,
+    z_index: &mut i32,
+) {
+    let node = &occlusion_data.node;
+    for (child, offset) in occlusion_data.children {
+        let cp = child.node.get_common_properties();
+        let cp = borrow!(cp);
+        let unclippable = cp.unclippable.get().unwrap_or(false);
+        let clips = borrow!(child.node.instance_node).clips_content(&child.node);
+        update_node_occlusion_recursive(
+            child,
+            ctx,
+            layer_offset + offset,
+            (clipping | clips) & !unclippable,
+            z_index,
+        );
+    }
+
+    let new_occlusion = Occlusion {
+        occlusion_layer_id: layer_offset,
+        z_index: *z_index,
+        parent_frame: occlusion_data
+            .node
+            .parent_frame
+            .get()
+            .filter(|_| clipping)
+            .map(|v| v.to_u32()),
+    };
+    let layer = borrow!(node.instance_node).base().flags().layer;
+    if (layer == Layer::Native || borrow!(node.instance_node).clips_content(&node))
+        && node.occlusion.get() != new_occlusion
+    {
+        let occlusion_patch = OcclusionPatch {
+            id: node.id.to_u32(),
+            z_index: new_occlusion.z_index,
+            occlusion_layer_id: new_occlusion.occlusion_layer_id,
+            parent_frame: new_occlusion.parent_frame,
+        };
+        ctx.enqueue_native_message(pax_message::NativeMessage::OcclusionUpdate(occlusion_patch));
+    }
+    node.occlusion.set(new_occlusion);
+    *z_index += 1;
+}
+
+fn calculate_occlusion_data(node: &Rc<ExpandedNode>) -> NodeOcclusionData {
+    let mut occlusion_set_self = OcclusionSet::default();
+    let instance_node = borrow!(node.instance_node);
+    let layer = instance_node.base().flags().layer;
+    match layer {
+        pax_runtime_api::Layer::Native => {
+            occlusion_set_self.bounds_native = Some(OcclusionBox::new_from_transform_and_bounds(
+                node.transform_and_bounds.get(),
+            ))
+        }
+        pax_runtime_api::Layer::Canvas => {
+            occlusion_set_self.bounds_canvas = Some(OcclusionBox::new_from_transform_and_bounds(
+                node.transform_and_bounds.get(),
+            ))
+        }
+        pax_runtime_api::Layer::DontCare => (),
+    }
+    let mut combined = OcclusionSet::default();
+    let mut children = vec![];
+    for child in node.children.get().iter().rev() {
+        let child_data = calculate_occlusion_data(&child);
+        let container_occlusion_offset = combined.merge_above(&child_data.occlusion_set);
+        if DEBUG_ON.load(Ordering::Relaxed) {
+            log::debug!("accum combined: {:?}", combined);
+        }
+        children.push((child_data, container_occlusion_offset));
+    }
+    combined.merge_above(&occlusion_set_self);
+    NodeOcclusionData {
+        occlusion_set: combined,
+        node: Rc::clone(&node),
+        children,
+    }
+}

--- a/pax-std/src/core/scrollbar.rs
+++ b/pax-std/src/core/scrollbar.rs
@@ -178,8 +178,12 @@ impl InstanceNode for ScrollbarInstance {
     ) {
         if let NativeInterrupt::Scrollbar(args) = interrupt {
             expanded_node.with_properties_unwrapped(|props: &mut Scrollbar| {
-                props.scroll_x.set(args.scroll_x);
-                props.scroll_y.set(args.scroll_y);
+                if (props.scroll_x.get() - args.scroll_x) > 1e-4 {
+                    props.scroll_x.set(args.scroll_x);
+                }
+                if (props.scroll_y.get() - args.scroll_y) > 1e-4 {
+                    props.scroll_y.set(args.scroll_y);
+                }
             });
         }
     }


### PR DESCRIPTION
After trying a few different approximation variants I ended up deleting everything and going with the simplest possible "perfect" O(n^2) solution for managing occlusion. Perf wise the designer hits other bottlenecks before this calc grows unboundedly, and could be improved with a quad-tree like structure, or replaced with an estimation method at some point in the future.

I also hooked back in shrinking of the number of canvases, not exactly sure what impact this has when a lot of things are changing on screen (might be slower than just keeping them around). But improves steady state after for example opening the color picker and closing it again.