### PR TITLE
Perf improvements + fixes for partial and full reloads

### DIFF
--- a/pax-compiler/templates/cartridge_generation/macros.tera
+++ b/pax-compiler/templates/cartridge_generation/macros.tera
@@ -3,14 +3,92 @@ struct {{component.pascal_identifier}}Factory{}
 
 impl {{ engine_import_path }}::pax_runtime::ComponentFactory for {{component.pascal_identifier}}Factory {
 
-    fn build_default_properties(&self) -> Box<dyn Fn(std::rc::Rc<{{ engine_import_path }}::pax_runtime::RuntimePropertiesStackFrame>) -> std::rc::Rc<RefCell<{{ engine_import_path }}::api::pax_value::PaxAny>>> {
-        Box::new(|_| std::rc::Rc::new(RefCell::new({{component.type_id.import_path}}::default().to_pax_any())))
+    fn build_default_properties(&self) -> Box<dyn Fn(std::rc::Rc<{{ engine_import_path }}::pax_runtime::RuntimePropertiesStackFrame>, Option<std::rc::Rc<crate::pax_runtime::ExpandedNode>>) -> Option<std::rc::Rc<RefCell<{{ engine_import_path }}::api::pax_value::PaxAny>>>> {
+        Box::new(|_,_| Some(std::rc::Rc::new(RefCell::new({{component.type_id.import_path}}::default().to_pax_any()))))
     }
 
-    fn build_inline_properties(&self, defined_properties: std::collections::BTreeMap<String,{{ engine_import_path }}::pax_manifest::ValueDefinition>) -> Box<dyn Fn(std::rc::Rc<{{ engine_import_path }}::pax_runtime::RuntimePropertiesStackFrame>) -> std::rc::Rc<RefCell<{{ engine_import_path }}::api::pax_value::PaxAny>>> {
-       
-        Box::new(move |stack_frame | std::rc::Rc::new(RefCell::new(
-            {
+    fn build_inline_properties(&self, defined_properties: std::collections::BTreeMap<String,{{ engine_import_path }}::pax_manifest::ValueDefinition>) -> Box<dyn Fn(std::rc::Rc<{{ engine_import_path }}::pax_runtime::RuntimePropertiesStackFrame>, Option<std::rc::Rc<crate::pax_runtime::ExpandedNode>>) -> Option<std::rc::Rc<RefCell<{{ engine_import_path }}::api::pax_value::PaxAny>>>> {
+
+        Box::new(move |stack_frame, expanded_node | {
+            if let Some(expanded_node) = &expanded_node {
+                use std::borrow::Borrow;
+                let expanded_node = pax_message::borrow!(**expanded_node);
+                let outer_ref = pax_message::borrow!(expanded_node.properties);
+                let rc = std::rc::Rc::clone(&outer_ref);
+                let mut inner_ref = (*rc).borrow_mut();
+                let mut properties  = {{component.type_id.import_path}}::mut_from_pax_any(&mut inner_ref).unwrap();
+                {% for property in component.properties %}
+                if let Some(vd) = defined_properties.get("{{property.name}}") {
+                        match vd.clone() {
+                            {{ engine_import_path }}::pax_manifest::ValueDefinition::LiteralValue(lv) => {
+                                let value = <{{property.property_type.type_id._type_id}}>::try_coerce(lv.clone()).unwrap();
+                                properties.{{property.name}}.replace_with(Property::new_with_name(value, "{{property.name}}"));
+                            },
+                            {{ engine_import_path }}::pax_manifest::ValueDefinition::DoubleBinding(identifier) => {
+                                let identifier = identifier.name;
+                                let untyped_property = stack_frame.resolve_symbol_as_erased_property(&identifier).expect(&format!("failed to resolve identifier: {}", &identifier));
+                                properties.{{property.name}} = Property::new_from_untyped(untyped_property.clone());
+                            },
+                            {{ engine_import_path }}::pax_manifest::ValueDefinition::Identifier(ident)  => {
+                                let variable = if let Some(p) = stack_frame.resolve_symbol_as_variable(&ident.name) {
+                                    p
+                                    } else {
+                                        panic!("Failed to resolve symbol {}", ident.name);
+                                    };
+                                    let name = ident.name.clone();
+                                    let untyped = variable.get_untyped_property().clone();
+                                    let cloned_variable = variable.clone();
+                                properties.{{property.name}} = Property::computed_with_name(
+                                        move || {
+                                            let new_value = cloned_variable.get_as_pax_value();
+                                            <{{property.property_type.type_id._type_id}}>::try_coerce(new_value).unwrap()
+                                        },
+                                        &[untyped],
+                                        &name,
+                                    );
+                            }
+                            
+                            {{ engine_import_path }}::pax_manifest::ValueDefinition::Expression(info) =>
+                            {
+                                let mut dependents = vec![];
+                                for dependency in &info.dependencies {
+                                    if let Some(p) = stack_frame.resolve_symbol_as_erased_property(dependency) {
+                                        dependents.push(p);
+                                    } else {
+                                        panic!("Failed to resolve symbol {}", dependency);
+                                    }
+                                }
+                                let cloned_stack = stack_frame.clone();
+                                properties.{{property.name}} = Property::computed_with_name(
+                                    move || {
+                                        let new_value = info.expression
+                                            .compute(cloned_stack.clone())
+                                            .expect(&format!("Failed to compute expr: {}", info.expression));
+                                        let coerced = <{{property.property_type.type_id._type_id}}>::try_coerce(new_value.clone());
+                                        let coerced = if let Err(e) = coerced {
+                                            panic!(
+                                                "Failed to coerce value: {},\n {:?}\n, {}\n",
+                                                e, new_value, info.expression
+                                            );
+                                        } else {
+                                            coerced.unwrap()
+                                        };
+                                        coerced
+                                    },
+                                    &dependents,
+                                    "{{property.name}}",
+                                );
+                            },
+                            {{ engine_import_path }}::pax_manifest::ValueDefinition::Block(block) => {
+                                let cloned_stack = stack_frame.clone();
+                                properties.{{property.name}}.replace_with({{property.property_type.type_id._type_id_escaped}}TypeFactory{}.build_type(&block, cloned_stack.clone()));
+                            }
+                            _ => unreachable!("Invalid value definition for {{property.name}}")
+                        }
+                }
+            {% endfor %}
+                None
+            } else {
                 let mut properties = {{component.type_id.import_path}}::default();
                 {% for property in component.properties %}
                     if let Some(vd) = defined_properties.get("{{property.name}}") {
@@ -27,20 +105,20 @@ impl {{ engine_import_path }}::pax_runtime::ComponentFactory for {{component.pas
                                 {{ engine_import_path }}::pax_manifest::ValueDefinition::Identifier(ident)  => {
                                     let variable = if let Some(p) = stack_frame.resolve_symbol_as_variable(&ident.name) {
                                         p
-                                     } else {
-                                         panic!("Failed to resolve symbol {}", ident.name);
-                                     };
-                                     let name = ident.name.clone();
-                                     let untyped = variable.get_untyped_property().clone();
-                                     let cloned_variable = variable.clone();
+                                        } else {
+                                            panic!("Failed to resolve symbol {}", ident.name);
+                                        };
+                                        let name = ident.name.clone();
+                                        let untyped = variable.get_untyped_property().clone();
+                                        let cloned_variable = variable.clone();
                                     properties.{{property.name}} = Property::computed_with_name(
-                                         move || {
-                                             let new_value = cloned_variable.get_as_pax_value();
-                                             <{{property.property_type.type_id._type_id}}>::try_coerce(new_value).unwrap()
-                                         },
-                                         &[untyped],
-                                         &name,
-                                     );
+                                            move || {
+                                                let new_value = cloned_variable.get_as_pax_value();
+                                                <{{property.property_type.type_id._type_id}}>::try_coerce(new_value).unwrap()
+                                            },
+                                            &[untyped],
+                                            &name,
+                                        );
                                 }
                                 
                                 {{ engine_import_path }}::pax_manifest::ValueDefinition::Expression(info) =>
@@ -82,9 +160,10 @@ impl {{ engine_import_path }}::pax_runtime::ComponentFactory for {{component.pas
                             }
                     }
                 {% endfor %}
-                properties.to_pax_any()
+            Some(std::rc::Rc::new(RefCell::new(properties.to_pax_any())))
             }
-        )))
+        }
+        )
     }
 
     fn build_handler(&self,fn_name: &str) -> fn(std::rc::Rc<RefCell<{{ engine_import_path }}::api::pax_value::PaxAny>>, &NodeContext, Option::<{{ engine_import_path }}::api::pax_value::PaxAny>) {

--- a/pax-language-server/src/positional.rs
+++ b/pax-language-server/src/positional.rs
@@ -29,7 +29,7 @@ pub enum NodeType {
 #[derive(Debug, Clone)]
 pub struct IdentifierData {
     pub identifier: String,
-    pub is_pascal_identifier: bool,
+    pub _is_pascal_identifier: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -120,7 +120,7 @@ pub fn extract_positional_nodes(
                     end,
                     node_type: NodeType::Identifier(IdentifierData {
                         identifier,
-                        is_pascal_identifier: true,
+                        _is_pascal_identifier: true,
                     }),
                 });
             }
@@ -143,7 +143,7 @@ pub fn extract_positional_nodes(
                 end,
                 node_type: NodeType::Identifier(IdentifierData {
                     identifier,
-                    is_pascal_identifier: true,
+                    _is_pascal_identifier: true,
                 }),
             });
         }
@@ -154,7 +154,7 @@ pub fn extract_positional_nodes(
                 end,
                 node_type: NodeType::Identifier(IdentifierData {
                     identifier,
-                    is_pascal_identifier: true,
+                    _is_pascal_identifier: true,
                 }),
             });
         }
@@ -165,7 +165,7 @@ pub fn extract_positional_nodes(
                 end,
                 node_type: NodeType::Identifier(IdentifierData {
                     identifier,
-                    is_pascal_identifier: false,
+                    _is_pascal_identifier: false,
                 }),
             });
         }

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -14,5 +14,5 @@ description = "Shared message structs used by Pax runtimes"
 
 [dependencies]
 serde = {version = "1.0.159", features=["derive"] }
-wasm-bindgen = {version = "0.2.92", features=["serde-serialize"]}
+wasm-bindgen = {version = "0.2.93", features=["serde-serialize"]}
 cfg-if = "1.0.0"

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ description = "Userland constructs used at the runtime API boundary of Pax Engin
 
 [dependencies]
 serde = {version = "1.0.159", features=["derive"] }
-wasm-bindgen = {version = "0.2.92", features=["serde-serialize"]}
+wasm-bindgen = {version = "0.2.93", features=["serde-serialize"]}
 kurbo = "0.9.0"
 piet = "0.6.0"
 slotmap = "1.0.7"

--- a/pax-runtime/Cargo.toml
+++ b/pax-runtime/Cargo.toml
@@ -23,7 +23,7 @@ pax-runtime-api = {version="0.35.0", path = "../pax-runtime-api"}
 piet = "0.6.0"
 piet-common = "0.6.0"
 serde = {version="1.0.196", features=["derive"]}
-wasm-bindgen = {version = "0.2.92", features=["serde-serialize"]}
+wasm-bindgen = {version = "0.2.93", features=["serde-serialize"]}
 
 [features]
 designtime = ["dep:pax-designtime"]

--- a/pax-runtime/src/cartridge.rs
+++ b/pax-runtime/src/cartridge.rs
@@ -173,8 +173,7 @@ pub trait DefinitionToInstanceTraverser {
                         let outer_ref = expanded_node.properties.borrow();
                         let rc = Rc::clone(&outer_ref);
                         let mut inner_ref = (*rc).borrow_mut();
-                        let mut cp =
-                            ConditionalProperties::mut_from_pax_any(&mut inner_ref).unwrap();
+                        let cp = ConditionalProperties::mut_from_pax_any(&mut inner_ref).unwrap();
                         cp.boolean_expression
                             .replace_with(Property::computed_with_name(
                                 move || {

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -203,7 +203,8 @@ impl ExpandedNode {
         containing_component: Weak<ExpandedNode>,
         parent: Weak<ExpandedNode>,
     ) -> Rc<Self> {
-        let properties = (&template.base().instance_prototypical_properties_factory)(env.clone());
+        let properties =
+            (&template.base().instance_prototypical_properties_factory)(env.clone(), None).unwrap();
         let common_properties =
             (&template
                 .base()
@@ -259,6 +260,10 @@ impl ExpandedNode {
         (&template
             .base()
             .instance_prototypical_common_properties_factory)(
+            Rc::clone(&self.stack),
+            Some(Rc::clone(&self)),
+        );
+        (&template.base().instance_prototypical_properties_factory)(
             Rc::clone(&self.stack),
             Some(Rc::clone(&self)),
         );

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -302,14 +302,6 @@ impl PaxEngine {
             .runtime_context
             .get_expanded_nodes_by_global_ids(&unique_id);
         for node in nodes {
-            if new_instance.base().template_node_identifier
-                == borrow!(self.runtime_context.userland_frame_instance_node)
-                    .base()
-                    .template_node_identifier
-            {
-                *borrow_mut!(self.runtime_context.userland_frame_instance_node) =
-                    Rc::clone(&new_instance);
-            }
             node.recreate_with_new_data(new_instance.clone(), &self.runtime_context);
         }
     }
@@ -320,10 +312,9 @@ impl PaxEngine {
             .as_ref()
             .map(Rc::clone)
             .unwrap();
-
-        Rc::clone(&node).recurse_unmount(&self.runtime_context);
-        node.recreate_with_new_data(new_userland_instance.clone(), &self.runtime_context);
-        Rc::clone(&node).recurse_mount(&self.runtime_context);
+        *borrow_mut!(self.runtime_context.userland_frame_instance_node) =
+            Rc::clone(&new_userland_instance);
+        node.fully_recreate_with_new_data(new_userland_instance.clone(), &self.runtime_context);
     }
 
     // NOTES: this is the order of different things being computed in recurse-expand-nodes

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -26,8 +26,12 @@ pub struct InstantiationArgs {
             Option<Rc<ExpandedNode>>,
         ) -> Option<Rc<RefCell<CommonProperties>>>,
     >,
-    pub prototypical_properties_factory:
-        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>) -> Rc<RefCell<PaxAny>>>,
+    pub prototypical_properties_factory: Box<
+        dyn Fn(
+            Rc<RuntimePropertiesStackFrame>,
+            Option<Rc<ExpandedNode>>,
+        ) -> Option<Rc<RefCell<PaxAny>>>,
+    >,
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
     pub children: Option<InstanceNodePtrList>,
     pub component_template: Option<InstanceNodePtrList>,
@@ -181,8 +185,12 @@ pub trait InstanceNode {
 
 pub struct BaseInstance {
     pub handler_registry: Option<Rc<RefCell<HandlerRegistry>>>,
-    pub instance_prototypical_properties_factory:
-        Box<dyn Fn(Rc<RuntimePropertiesStackFrame>) -> Rc<RefCell<PaxAny>>>,
+    pub instance_prototypical_properties_factory: Box<
+        dyn Fn(
+            Rc<RuntimePropertiesStackFrame>,
+            Option<Rc<ExpandedNode>>,
+        ) -> Option<Rc<RefCell<PaxAny>>>,
+    >,
     pub instance_prototypical_common_properties_factory: Box<
         dyn Fn(
             Rc<RuntimePropertiesStackFrame>,


### PR DESCRIPTION
We now update properties in place for all properties instead of re-churning the subtree. I also fixed a bug from the full reload refactor.